### PR TITLE
feat: add multi-game support and runtime localization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ profiles/*.local.json
 # Ngu canh lam viec, khong public
 HANDOFF.md
 profiles/pubg-vn.json
+profiles/cs2-vn.json
 .gitignore
 
 # Local machine settings for ./gpb and gpb.ps1 (relay host aliases and the like)
@@ -59,6 +60,7 @@ docs/COMMERCIAL.md
 
 # Installer output
 installer/dist/
+dist/
 
 # Cong cu va tai lieu van hanh, khong public
 licence-gen

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Game Ping Booster
 
-Latency reducer for PUBG on Windows, aimed at players in Vietnam. Gameplay traffic is diverted
-through a VPS abroad whose route to the game servers beats the one the local ISP picks by default.
+Low-latency network optimizer for Counter-Strike 2 (CS2) and PUBG on Windows, aimed at players in Vietnam and Southeast Asia. Gameplay traffic is diverted
+through a high-speed VPS abroad whose route to the game servers beats the one the local ISP picks by default.
+
+Supports game selection via the UI (Counter-Strike 2, PUBG: BATTLEGROUNDS) with bilingual localization (English & Vietnamese).
 
 No injection, no reading game memory, no DLL hooks. The whole mechanism is a virtual network
 adapter plus entries in the Windows routing table: destinations belonging to the game go through
@@ -33,19 +35,21 @@ Routing works on destination addresses, so the profile has to say which addresse
 game - and it has to be narrow. AWS and Azure publish the enclosing blocks as `/17`s and `/18`s;
 routing one of those would drag thousands of unrelated services through the relay.
 
-`tools/profile-builder/` solves that in two commands:
+`tools/profile-builder/` provides builders for both games:
 
 ```powershell
 cd tools\profile-builder
+
+# For CS2: fetch live Valve SDR POPs directly from the Steam API:
+.\Build-Cs2Profile.ps1
+
+# For PUBG: capture and build from observed sessions:
 .\Capture-GameTraffic.ps1     # leave running, play, Ctrl+C when done
 .\Build-PubgProfile.ps1       # no arguments
 ```
 
-The first watches for the game process, captures while it runs, attributes traffic to the process
-by joining captured source ports against the Windows UDP socket table, and appends the servers it
-saw. The second cross-checks every address against the official AWS and Azure range files, keeps
-each one narrow, sorts it into the right region, writes `profiles/pubg-vn.json` and validates the
-result.
+For CS2, all 41+ Valve Steam Datagram Relay (SDR) clusters are fetched directly from the official Steam Web API and mapped to dedicated /24 subnets.
+For PUBG, the tool watches the game process, attributes traffic from the socket table, cross-checks against Azure/AWS ranges, and writes `profiles/pubg-vn.json`.
 
 Addresses that belong to no published cloud range are never added automatically; they are set
 aside for review. In practice they turn out to be voice chat or a CDN.

--- a/client/config.example.json
+++ b/client/config.example.json
@@ -1,10 +1,10 @@
 {
   "profileUrl": "",
-  "profilePath": "profiles/pubg-vn.json",
+  "profilePath": "profiles",
   "psk": "PASTE-THE-PSK-FROM-THE-VPS-HERE",
   "defaultRelayId": "sg-1",
   "relayEndpoints": [],
-  "defaultGameId": "pubg",
+  "defaultGameId": "",
   "adapterName": "Game Ping Booster",
   "routeWithoutGame": false
 }

--- a/client/src/GamePingBooster.App/App.axaml.cs
+++ b/client/src/GamePingBooster.App/App.axaml.cs
@@ -1,4 +1,4 @@
-﻿using Avalonia;
+using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
 using Avalonia.Threading;
@@ -74,7 +74,10 @@ public partial class App : Application
                 var written = status.ProfileUpdatedAt is { } unix
                     ? DateTimeOffset.FromUnixTimeSeconds(unix)
                     : (DateTimeOffset?)null;
-                _ = _profileSync.SyncAsync(status.LicenceUrl, status.DevicePublicKey, "pubg", false, written);
+                var initialGame = !string.IsNullOrWhiteSpace(status.SelectedGameId)
+                    ? status.SelectedGameId
+                    : (status.AvailableGames.FirstOrDefault()?.Id ?? "cs2");
+                _ = _profileSync.SyncAsync(status.LicenceUrl, status.DevicePublicKey, initialGame, false, written);
             }
 
             // The catch-all: closing the main window is handled in MainWindow.OnClosing,

--- a/client/src/GamePingBooster.App/GamePingBooster.App.csproj
+++ b/client/src/GamePingBooster.App/GamePingBooster.App.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
@@ -34,6 +34,7 @@
          next to it. ApplicationIcon above is separate - that one is the icon Explorer draws on
          the .exe and is baked in by the linker. -->
     <AvaloniaResource Include="favicon.ico" />
+    <AvaloniaResource Include="Resources\Languages\*.xml" />
   </ItemGroup>
 
   <ItemGroup>

--- a/client/src/GamePingBooster.App/Resources/Languages/Strings.en.xml
+++ b/client/src/GamePingBooster.App/Resources/Languages/Strings.en.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Resources>
+  <!-- Connection state -->
+  <String Key="Status.Disconnected">Not connected</String>
+  <String Key="Status.Connecting">Connecting...</String>
+  <String Key="Status.Connected">Connected</String>
+  <String Key="Status.ConnectedWaitingGame">Connected (Waiting for game)</String>
+  <String Key="Status.Reconnecting">Reconnecting...</String>
+  <String Key="Status.Error">Error</String>
+  <String Key="Status.Unknown">Unknown</String>
+
+  <!-- Action button -->
+  <String Key="Action.Connect">Connect</String>
+  <String Key="Action.Disconnect">Disconnect</String>
+
+  <!-- Labels -->
+  <String Key="Label.PingInGame">Ping in game</String>
+  <String Key="Label.PingToRelay">Ping to relay</String>
+  <String Key="Label.PacketLoss">Packet loss</String>
+  <String Key="Label.RelayServer">RELAY SERVER</String>
+  <String Key="Label.Game">GAME</String>
+  <String Key="Label.Routing">ROUTING</String>
+  <String Key="Label.Packets">PACKETS</String>
+  <String Key="Selector.Placeholder">Select your game</String>
+  <String Key="Banner.NoRelay">No relay configured yet. Open Settings and enter your relay's address and key.</String>
+
+  <!-- Menu -->
+  <String Key="Menu.Account">Account</String>
+  <String Key="Menu.SignIn">Sign in</String>
+  <String Key="Menu.Settings">Settings</String>
+  <String Key="Menu.Language">Language</String>
+  <String Key="Menu.LanguageVi">Tiếng Việt</String>
+  <String Key="Menu.LanguageEn">English</String>
+  <String Key="Menu.ReportLag">Report lag</String>
+  <String Key="Menu.Logs">Open logs folder</String>
+  <String Key="Menu.About">About</String>
+  <String Key="Menu.Update">Update to latest version (v{0})</String>
+
+  <!-- System Tray -->
+  <String Key="Tray.Show">Show Game Ping Booster</String>
+  <String Key="Tray.Exit">Exit</String>
+
+  <!-- Game notices -->
+  <String Key="Game.NoSelected">No game selected</String>
+  <String Key="Game.Running">{0} is running</String>
+  <String Key="Game.WaitingToLaunch">Waiting for {0} to launch...</String>
+  <String Key="Game.NotOpen">{0} is not open</String>
+  <String Key="Warning.SelectGame">Please select a game first.</String>
+  <String Key="Detail.SelectGame">Choose your game from the dropdown above before connecting.</String>
+
+  <!-- Licence status -->
+  <String Key="Licence.NotSignedIn">Not signed in</String>
+  <String Key="Licence.SignedIn">Signed in</String>
+  <String Key="Licence.UsingInstalledProfile">Signed in - using the installed game list, not the current one</String>
+  <String Key="Licence.Expired">Licence expired - sign in again</String>
+  <String Key="Licence.ExpiresSoon">Licence expires in {0} min</String>
+  <String Key="Licence.ValidUntil">Signed in, licence valid until {0}</String>
+
+  <!-- Detail messages -->
+  <String Key="Detail.StartingUp">Starting up...</String>
+  <String Key="Detail.Disconnected">Disconnected.</String>
+  <String Key="Detail.Disconnecting">Disconnecting...</String>
+  <String Key="Detail.ResolvingRelay">Resolving relay address...</String>
+  <String Key="Detail.ConfiguringAdapter">Configuring network adapter...</String>
+  <String Key="Detail.ConnectingToRelay">Connecting to relay...</String>
+  <String Key="Detail.WaitingForGame">Connected to Relay. Please open {0} to start optimizing...</String>
+  <String Key="Detail.Optimizing">Optimizing {0} through {1}</String>
+  <String Key="Detail.GettingServerList">Getting the latest server list...</String>
+  <String Key="Detail.SendingRequest">Sending the request to the background service...</String>
+
+  <!-- Metrics -->
+  <String Key="Metrics.Direct">Direct</String>
+  <String Key="Metrics.Ranges">{0} ranges</String>
+  <String Key="Metrics.Packets">{0} up / {1} down</String>
+  <String Key="Metrics.ToRegion">{0} ms to {1}</String>
+</Resources>

--- a/client/src/GamePingBooster.App/Resources/Languages/Strings.vi.xml
+++ b/client/src/GamePingBooster.App/Resources/Languages/Strings.vi.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Resources>
+  <!-- Trạng thái kết nối -->
+  <String Key="Status.Disconnected">Chưa kết nối</String>
+  <String Key="Status.Connecting">Đang kết nối...</String>
+  <String Key="Status.Connected">Đã kết nối</String>
+  <String Key="Status.ConnectedWaitingGame">Đã kết nối (Chờ game)</String>
+  <String Key="Status.Reconnecting">Đang kết nối lại...</String>
+  <String Key="Status.Error">Lỗi</String>
+  <String Key="Status.Unknown">Không xác định</String>
+
+  <!-- Nút thao tác -->
+  <String Key="Action.Connect">Kết nối</String>
+  <String Key="Action.Disconnect">Ngắt kết nối</String>
+
+  <!-- Tiêu đề và nhãn -->
+  <String Key="Label.PingInGame">Ping trong game</String>
+  <String Key="Label.PingToRelay">Ping tới Relay</String>
+  <String Key="Label.PacketLoss">Packet loss</String>
+  <String Key="Label.RelayServer">MÁY CHỦ RELAY</String>
+  <String Key="Label.Game">GAME</String>
+  <String Key="Label.Routing">ĐỊNH TUYẾN</String>
+  <String Key="Label.Packets">GÓI TIN</String>
+  <String Key="Selector.Placeholder">Chọn game của bạn</String>
+  <String Key="Banner.NoRelay">Chưa cấu hình máy chủ Relay. Hãy mở Cài đặt và nhập địa chỉ cùng khoá của Relay.</String>
+
+  <!-- Menu góc phải -->
+  <String Key="Menu.Account">Tài khoản</String>
+  <String Key="Menu.SignIn">Đăng nhập</String>
+  <String Key="Menu.Settings">Cài đặt</String>
+  <String Key="Menu.Language">Ngôn ngữ</String>
+  <String Key="Menu.LanguageVi">Tiếng Việt</String>
+  <String Key="Menu.LanguageEn">English</String>
+  <String Key="Menu.ReportLag">Báo cáo lag</String>
+  <String Key="Menu.Logs">Mở thư mục logs</String>
+  <String Key="Menu.About">Giới thiệu</String>
+  <String Key="Menu.Update">Cập nhật bản mới nhất (v{0})</String>
+
+  <!-- Khay hệ thống -->
+  <String Key="Tray.Show">Mở Game Ping Booster</String>
+  <String Key="Tray.Exit">Thoát</String>
+
+  <!-- Thông báo game -->
+  <String Key="Game.NoSelected">Chưa chọn game</String>
+  <String Key="Game.Running">{0} đang chạy</String>
+  <String Key="Game.WaitingToLaunch">Đang chờ mở {0}...</String>
+  <String Key="Game.NotOpen">{0} chưa mở</String>
+  <String Key="Warning.SelectGame">Vui lòng chọn game trước.</String>
+  <String Key="Detail.SelectGame">Chọn game của bạn từ danh sách trước khi kết nối.</String>
+
+  <!-- Trạng thái bản quyền -->
+  <String Key="Licence.NotSignedIn">Chưa đăng nhập</String>
+  <String Key="Licence.SignedIn">Đã đăng nhập</String>
+  <String Key="Licence.UsingInstalledProfile">Đã đăng nhập - đang dùng danh sách game từ bản cài đặt</String>
+  <String Key="Licence.Expired">Bản quyền đã hết hạn - vui lòng đăng nhập lại</String>
+  <String Key="Licence.ExpiresSoon">Bản quyền hết hạn sau {0} phút</String>
+  <String Key="Licence.ValidUntil">Đã đăng nhập, bản quyền hợp lệ đến {0}</String>
+
+  <!-- Chi tiết trạng thái -->
+  <String Key="Detail.StartingUp">Đang khởi động...</String>
+  <String Key="Detail.Disconnected">Đã ngắt kết nối.</String>
+  <String Key="Detail.Disconnecting">Đang ngắt kết nối...</String>
+  <String Key="Detail.ResolvingRelay">Đang phân giải địa chỉ relay...</String>
+  <String Key="Detail.ConfiguringAdapter">Đang cấu hình card mạng...</String>
+  <String Key="Detail.ConnectingToRelay">Đang kết nối tới relay...</String>
+  <String Key="Detail.WaitingForGame">Đã kết nối tới Relay. Vui lòng mở {0} để bắt đầu tối ưu...</String>
+  <String Key="Detail.Optimizing">Đang tối ưu {0} qua {1}</String>
+  <String Key="Detail.GettingServerList">Đang tải danh sách máy chủ mới nhất...</String>
+  <String Key="Detail.SendingRequest">Đang gửi yêu cầu tới dịch vụ hệ thống...</String>
+
+  <!-- Thông số -->
+  <String Key="Metrics.Direct">Trực tiếp</String>
+  <String Key="Metrics.Ranges">{0} dải IP</String>
+  <String Key="Metrics.Packets">{0} gửi / {1} nhận</String>
+  <String Key="Metrics.ToRegion">{0} ms tới {1}</String>
+</Resources>

--- a/client/src/GamePingBooster.App/Services/LicenceClient.cs
+++ b/client/src/GamePingBooster.App/Services/LicenceClient.cs
@@ -1,9 +1,11 @@
-﻿using System.Net.Http;
+using System.Net;
+using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
+using System.Threading;
 using GamePingBooster.Core.Protocol;
 
 namespace GamePingBooster.App.Services;
@@ -64,7 +66,7 @@ public sealed class LicenceClient : IDisposable
             BaseAddress = new Uri(baseUrl.TrimEnd('/') + "/"),
             // Off. Each call sets its own deadline in WithDeadline, because one number for every
             // call is wrong for the exchange - see ExchangeTimeout.
-            Timeout = System.Threading.Timeout.InfiniteTimeSpan,
+            Timeout = Timeout.InfiniteTimeSpan,
         };
     }
 
@@ -254,9 +256,9 @@ public sealed class LicenceClient : IDisposable
 
             throw await ErrorAsync(response, t, new()
             {
-                [System.Net.HttpStatusCode.Unauthorized] = "Sign in again to update the game list.",
-                [System.Net.HttpStatusCode.PaymentRequired] = "This account has no active subscription.",
-                [System.Net.HttpStatusCode.TooManyRequests] = "Asked for the game list too often. It will update later.",
+                [HttpStatusCode.Unauthorized] = "Sign in again to update the game list.",
+                [HttpStatusCode.PaymentRequired] = "This account has no active subscription.",
+                [HttpStatusCode.TooManyRequests] = "Asked for the game list too often. It will update later.",
             }).ConfigureAwait(false);
         });
 
@@ -278,18 +280,15 @@ public sealed class LicenceClient : IDisposable
 
             throw await ErrorAsync(response, t, new()
             {
-                [System.Net.HttpStatusCode.Unauthorized] = "This sign-in has expired. Sign in again.",
+                [HttpStatusCode.Unauthorized] = "This sign-in has expired. Sign in again.",
             }).ConfigureAwait(false);
         });
 
     /// <summary>
-    /// Ends the sign-in on the server.
-    ///
-    /// Best effort: signing out locally must succeed whether or not this does, because a person
-    /// who wants their credentials off a machine should not be blocked by a network that is
-    /// down. The credential is short-lived and revoking it is hygiene, not the mechanism.
+    /// Ends this device's sign-in on the licence server. Fire-and-forget: we discard the token
+    /// locally regardless, and an unreached server will let the token expire on its own.
     /// </summary>
-    public Task LogoutAsync(string refreshToken, CancellationToken ct) =>
+    public Task<bool> LogoutAsync(string refreshToken, CancellationToken ct) =>
         WithDeadline(RequestTimeout, ct, async t =>
         {
             using var request = new HttpRequestMessage(HttpMethod.Post, "auth/logout");
@@ -299,7 +298,7 @@ public sealed class LicenceClient : IDisposable
         });
 
     private static async Task<LicenceException> ErrorAsync(HttpResponseMessage response,
-        CancellationToken ct, Dictionary<System.Net.HttpStatusCode, string> known)
+        CancellationToken ct, Dictionary<HttpStatusCode, string> known)
     {
         string? serverMessage = null;
         try
@@ -356,9 +355,9 @@ public sealed class LicenceClient : IDisposable
         {
             // No password is ever sent from here, so a 401 can only mean the sign-in itself is no
             // longer accepted - an expired or revoked refresh token, or a one-time code already spent.
-            System.Net.HttpStatusCode.Unauthorized => "That sign-in is no longer valid. Sign in again.",
-            System.Net.HttpStatusCode.Forbidden => "This account is not allowed to add another device.",
-            System.Net.HttpStatusCode.NotFound => "The licence server does not recognise this request. Check the address in settings.",
+            HttpStatusCode.Unauthorized => "That sign-in is no longer valid. Sign in again.",
+            HttpStatusCode.Forbidden => "This account is not allowed to add another device.",
+            HttpStatusCode.NotFound => "The licence server does not recognise this request. Check the address in settings.",
             _ => $"The licence server answered {(int)response.StatusCode}.",
         }, response.StatusCode);
     }
@@ -372,11 +371,11 @@ public sealed class LicenceClient : IDisposable
 /// retrying, and "this account has no subscription", which is not and which should drop the
 /// licence rather than keep presenting it. Every other caller still reads only Message.
 /// </summary>
-public sealed class LicenceException(string message, System.Net.HttpStatusCode? status = null)
+public sealed class LicenceException(string message, HttpStatusCode? status = null)
     : Exception(message)
 {
     /// <summary>The HTTP status behind it, or null when the request never got an answer.</summary>
-    public System.Net.HttpStatusCode? StatusCode { get; } = status;
+    public HttpStatusCode? StatusCode { get; } = status;
 }
 
 /// <summary>

--- a/client/src/GamePingBooster.App/Services/Localization.cs
+++ b/client/src/GamePingBooster.App/Services/Localization.cs
@@ -1,0 +1,187 @@
+using System.Diagnostics;
+using System.Globalization;
+using System.Xml.Linq;
+using Avalonia.Platform;
+
+namespace GamePingBooster.App.Services;
+
+public enum AppLanguage
+{
+    Vietnamese,
+    English
+}
+
+/// <summary>
+/// Manages application-wide internationalization (i18n) by parsing XML language resources
+/// (Resources/Languages/Strings.vi.xml and Strings.en.xml).
+/// </summary>
+public static class Localization
+{
+    private static readonly string SettingsDir = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "GamePingBooster");
+    private static readonly string LanguageFile = Path.Combine(SettingsDir, "language.txt");
+
+    private static readonly Dictionary<string, string> ViStrings = new(StringComparer.OrdinalIgnoreCase);
+    private static readonly Dictionary<string, string> EnStrings = new(StringComparer.OrdinalIgnoreCase);
+
+    static Localization()
+    {
+        LoadXml("vi", ViStrings);
+        LoadXml("en", EnStrings);
+    }
+
+    private static void LoadXml(string lang, Dictionary<string, string> dict)
+    {
+        try
+        {
+            var uri = new Uri($"avares://GamePingBooster/Resources/Languages/Strings.{lang}.xml");
+            if (AssetLoader.Exists(uri))
+            {
+                using var stream = AssetLoader.Open(uri);
+                var doc = XDocument.Load(stream);
+                foreach (var el in doc.Descendants("String"))
+                {
+                    var key = el.Attribute("Key")?.Value;
+                    if (!string.IsNullOrEmpty(key))
+                    {
+                        dict[key] = el.Value;
+                    }
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Failed to load {lang} XML: {ex.Message}");
+        }
+    }
+
+    public static AppLanguage CurrentLanguage { get; private set; } = DetectInitialLanguage();
+
+    public static event Action? LanguageChanged;
+
+    private static AppLanguage DetectInitialLanguage()
+    {
+        try
+        {
+            if (File.Exists(LanguageFile))
+            {
+                var text = File.ReadAllText(LanguageFile).Trim();
+                if (text.Equals("en", StringComparison.OrdinalIgnoreCase) ||
+                    text.Equals("English", StringComparison.OrdinalIgnoreCase))
+                {
+                    return AppLanguage.English;
+                }
+                if (text.Equals("vi", StringComparison.OrdinalIgnoreCase) ||
+                    text.Equals("Vietnamese", StringComparison.OrdinalIgnoreCase))
+                {
+                    return AppLanguage.Vietnamese;
+                }
+            }
+
+            var culture = CultureInfo.CurrentUICulture.Name;
+            if (culture.StartsWith("vi", StringComparison.OrdinalIgnoreCase))
+            {
+                return AppLanguage.Vietnamese;
+            }
+        }
+        catch
+        {
+        }
+
+        return AppLanguage.Vietnamese;
+    }
+
+    public static void SetLanguage(AppLanguage language)
+    {
+        if (CurrentLanguage == language) return;
+        CurrentLanguage = language;
+
+        try
+        {
+            Directory.CreateDirectory(SettingsDir);
+            File.WriteAllText(LanguageFile, language == AppLanguage.Vietnamese ? "vi" : "en");
+        }
+        catch
+        {
+        }
+
+        LanguageChanged?.Invoke();
+    }
+
+    public static bool IsVietnamese => CurrentLanguage == AppLanguage.Vietnamese;
+
+    /// <summary>
+    /// Looks up a string by Key from the active language's XML resource file.
+    /// </summary>
+    public static string GetString(string key, params object[] args)
+    {
+        var dict = IsVietnamese ? ViStrings : EnStrings;
+        if (!dict.TryGetValue(key, out var val))
+        {
+            if (!EnStrings.TryGetValue(key, out val))
+            {
+                return key;
+            }
+        }
+
+        if (args.Length > 0)
+        {
+            try
+            {
+                return string.Format(val, args);
+            }
+            catch
+            {
+                return val;
+            }
+        }
+
+        return val;
+    }
+
+    /// <summary>
+    /// Shorthand alias for GetString.
+    /// </summary>
+    public static string T(string key, params object[] args) => GetString(key, args);
+
+    /// <summary>
+    /// Translates service detail strings using XML keys while preserving dynamic game/relay names.
+    /// </summary>
+    public static string LocalizeDetail(string? detail, string? gameName, string? relayName)
+    {
+        if (string.IsNullOrWhiteSpace(detail)) return "";
+
+        if (detail.StartsWith("Waiting for game to launch", StringComparison.OrdinalIgnoreCase) ||
+            detail.StartsWith("Connected to", StringComparison.OrdinalIgnoreCase))
+        {
+            return GetString("Detail.WaitingForGame", gameName ?? "game");
+        }
+        if (detail.StartsWith("Optimizing", StringComparison.OrdinalIgnoreCase) ||
+            detail.StartsWith("Accelerating", StringComparison.OrdinalIgnoreCase))
+        {
+            return GetString("Detail.Optimizing", gameName ?? "game", relayName ?? "Relay");
+        }
+        if (detail.Equals("Starting up...", StringComparison.OrdinalIgnoreCase))
+            return GetString("Detail.StartingUp");
+        if (detail.Equals("Disconnected.", StringComparison.OrdinalIgnoreCase) ||
+            detail.Equals("Disconnected", StringComparison.OrdinalIgnoreCase))
+            return GetString("Detail.Disconnected");
+        if (detail.Equals("Disconnecting...", StringComparison.OrdinalIgnoreCase))
+            return GetString("Detail.Disconnecting");
+        if (detail.Equals("Resolving relay address...", StringComparison.OrdinalIgnoreCase))
+            return GetString("Detail.ResolvingRelay");
+        if (detail.Equals("Configuring network adapter...", StringComparison.OrdinalIgnoreCase))
+            return GetString("Detail.ConfiguringAdapter");
+        if (detail.Equals("Connecting to relay...", StringComparison.OrdinalIgnoreCase))
+            return GetString("Detail.ConnectingToRelay");
+        if (detail.Equals("Getting the latest server list...", StringComparison.OrdinalIgnoreCase))
+            return GetString("Detail.GettingServerList");
+        if (detail.Equals("Sending the request to the background service...", StringComparison.OrdinalIgnoreCase))
+            return GetString("Detail.SendingRequest");
+        if (detail.Equals("Choose your game from the dropdown above before connecting.", StringComparison.OrdinalIgnoreCase))
+            return GetString("Detail.SelectGame");
+
+        return detail;
+    }
+}

--- a/client/src/GamePingBooster.App/Services/PipeClient.cs
+++ b/client/src/GamePingBooster.App/Services/PipeClient.cs
@@ -85,8 +85,7 @@ public sealed class PipeClient : IAsyncDisposable
 
     public async Task SendAsync(CommandMessage command)
     {
-        var writer = _writer;
-        if (writer is null) throw new InvalidOperationException("Not connected to the background service.");
+        var writer = _writer ?? throw new InvalidOperationException("Not connected to the background service.");
 
         var json = JsonSerializer.Serialize(command, IpcJsonContext.Default.CommandMessage);
         await writer.WriteLineAsync(json).ConfigureAwait(false);
@@ -94,6 +93,9 @@ public sealed class PipeClient : IAsyncDisposable
 
     public Task ConnectTunnelAsync(string? relayId = null, string? gameId = null)
         => SendAsync(new CommandMessage { Verb = "connect", RelayId = relayId, GameId = gameId });
+
+    public Task SelectGameAsync(string gameId)
+        => SendAsync(new CommandMessage { Verb = "select-game", GameId = gameId });
 
     public Task DisconnectTunnelAsync() => SendAsync(new CommandMessage { Verb = "disconnect" });
 

--- a/client/src/GamePingBooster.App/Services/ProfileSync.cs
+++ b/client/src/GamePingBooster.App/Services/ProfileSync.cs
@@ -1,4 +1,5 @@
-﻿using GamePingBooster.Core.Ipc;
+using System.Net;
+using GamePingBooster.Core.Ipc;
 
 namespace GamePingBooster.App.Services;
 
@@ -137,7 +138,7 @@ public sealed class ProfileSync
             // Everything else IS worth showing. "No active subscription" is actionable, and the
             // tunnel quietly running on months-old ranges is exactly the sort of thing that goes
             // unnoticed.
-            if (ex.StatusCode == System.Net.HttpStatusCode.TooManyRequests) return;
+            if (ex.StatusCode == HttpStatusCode.TooManyRequests) return;
 
             _report($"Could not update the game list: {ex.Message}");
         }

--- a/client/src/GamePingBooster.App/Services/RefreshTokenStore.cs
+++ b/client/src/GamePingBooster.App/Services/RefreshTokenStore.cs
@@ -1,4 +1,6 @@
+using System.IO;
 using System.Security.Cryptography;
+using System.Text;
 
 namespace GamePingBooster.App.Services;
 
@@ -29,11 +31,11 @@ public static class RefreshTokenStore
     /// <summary>See DeviceIdentity.Entropy: a domain separator, not a secret.</summary>
     private static readonly byte[] Entropy = "GamePingBooster.RefreshToken.v1"u8.ToArray();
 
-    private static string Directory =>
+    private static string DirectoryPath =>
         Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
             "GamePingBooster");
 
-    private static string FilePath => Path.Combine(Directory, FileName);
+    private static string FilePath => Path.Combine(DirectoryPath, FileName);
 
     public static string? Load()
     {
@@ -42,7 +44,7 @@ public static class RefreshTokenStore
             if (!File.Exists(FilePath)) return null;
             var blob = File.ReadAllBytes(FilePath);
             var raw = ProtectedData.Unprotect(blob, Entropy, DataProtectionScope.CurrentUser);
-            var text = System.Text.Encoding.UTF8.GetString(raw);
+            var text = Encoding.UTF8.GetString(raw);
             return string.IsNullOrWhiteSpace(text) ? null : text;
         }
         catch (Exception)
@@ -56,8 +58,8 @@ public static class RefreshTokenStore
     {
         try
         {
-            System.IO.Directory.CreateDirectory(Directory);
-            var blob = ProtectedData.Protect(System.Text.Encoding.UTF8.GetBytes(refreshToken),
+            Directory.CreateDirectory(DirectoryPath);
+            var blob = ProtectedData.Protect(Encoding.UTF8.GetBytes(refreshToken),
                 Entropy, DataProtectionScope.CurrentUser);
 
             // Temporary file then replace, for the same reason the service does it: a half

--- a/client/src/GamePingBooster.App/Services/TokenRefresher.cs
+++ b/client/src/GamePingBooster.App/Services/TokenRefresher.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using GamePingBooster.Core.Ipc;
 using GamePingBooster.Core.Protocol;
 
@@ -290,7 +291,7 @@ public sealed class TokenRefresher : IAsyncDisposable
             // Only 402. A 401, a 429 or a device-limit 403 are all things that can be true this
             // minute and false the next, and throwing away a working licence over one of them
             // would sign the user out of a session they were entitled to.
-            if (ex.StatusCode == System.Net.HttpStatusCode.PaymentRequired)
+            if (ex.StatusCode == HttpStatusCode.PaymentRequired)
             {
                 try
                 {

--- a/client/src/GamePingBooster.App/Services/UpdateChecker.cs
+++ b/client/src/GamePingBooster.App/Services/UpdateChecker.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
@@ -172,8 +173,8 @@ public sealed class UpdateChecker : IAsyncDisposable
         var numbers = new int[3];
         for (var i = 0; i < 3; i++)
         {
-            if (!int.TryParse(parts[i], System.Globalization.NumberStyles.None,
-                    System.Globalization.CultureInfo.InvariantCulture, out numbers[i]))
+            if (!int.TryParse(parts[i], NumberStyles.None,
+                    CultureInfo.InvariantCulture, out numbers[i]))
             {
                 return false;
             }

--- a/client/src/GamePingBooster.App/ViewModels/LoginViewModel.cs
+++ b/client/src/GamePingBooster.App/ViewModels/LoginViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using GamePingBooster.App.Services;
 
@@ -194,6 +194,9 @@ public sealed class LoginViewModel : INotifyPropertyChanged
         {
             // force: true, so the age of whatever profile is already stored is irrelevant and
             // there is nothing to pass for it.
+            await _profileSync
+                .SyncAsync(_licenceUrl, _devicePublicKey, "cs2", force: true, profileUpdatedAt: null, ct: ct)
+                .ConfigureAwait(true);
             await _profileSync
                 .SyncAsync(_licenceUrl, _devicePublicKey, "pubg", force: true, profileUpdatedAt: null, ct: ct)
                 .ConfigureAwait(true);

--- a/client/src/GamePingBooster.App/ViewModels/MainViewModel.cs
+++ b/client/src/GamePingBooster.App/ViewModels/MainViewModel.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using Avalonia.Media;
 using Avalonia.Threading;
@@ -21,6 +22,36 @@ public sealed class MainViewModel : INotifyPropertyChanged
         _pipe = pipe;
         _pipe.StatusReceived += OnStatus;
         _pipe.Disconnected += OnDisconnected;
+        Localization.LanguageChanged += OnLanguageChanged;
+    }
+
+    private void OnLanguageChanged()
+    {
+        Raise(nameof(StatusText));
+        Raise(nameof(ActionButtonText));
+        Raise(nameof(Detail));
+        Raise(nameof(GameText));
+        Raise(nameof(RouteText));
+        Raise(nameof(PacketsText));
+        Raise(nameof(GamePingText));
+        Raise(nameof(AccountMenuText));
+        Raise(nameof(UpdateMenuText));
+        Raise(nameof(LabelPingInGame));
+        Raise(nameof(LabelPingToRelay));
+        Raise(nameof(LabelPacketLoss));
+        Raise(nameof(LabelRelayServer));
+        Raise(nameof(LabelGame));
+        Raise(nameof(LabelRouting));
+        Raise(nameof(LabelPackets));
+        Raise(nameof(SelectGamePlaceholder));
+        Raise(nameof(NoRelayBannerText));
+        Raise(nameof(MenuSettingsText));
+        Raise(nameof(MenuLanguageText));
+        Raise(nameof(MenuLanguageViText));
+        Raise(nameof(MenuLanguageEnText));
+        Raise(nameof(MenuReportLagText));
+        Raise(nameof(MenuLogsText));
+        Raise(nameof(MenuAboutText));
     }
 
     // ------------------------------------------------------------ licence
@@ -113,7 +144,9 @@ public sealed class MainViewModel : INotifyPropertyChanged
     public bool ShowLicence => !string.IsNullOrWhiteSpace(LicenceUrl);
 
     /// <summary>What the menu item says. One entry, two states, no dead end either way.</summary>
-    public string AccountMenuText => HasToken ? "Account" : "Sign in";
+    public string AccountMenuText => HasToken
+        ? Localization.T("Menu.Account")
+        : Localization.T("Menu.SignIn");
 
     // ------------------------------------------------------------ updates
 
@@ -134,7 +167,7 @@ public sealed class MainViewModel : INotifyPropertyChanged
     public bool HasUpdate => Update is not null;
 
     /// <summary>The last line of the menu, and only there when a newer release exists.</summary>
-    public string UpdateMenuText => Update is null ? "" : $"Update to latest version (v{Update.Version})";
+    public string UpdateMenuText => Update is null ? "" : Localization.T("Menu.Update", Update.Version);
 
     /// <summary>
     /// The last thing the renewer had to say, if anything.
@@ -159,23 +192,23 @@ public sealed class MainViewModel : INotifyPropertyChanged
             // work is worse than no line at all.
             if (LicenceBlocked) return LicenceRefusal!;
             if (!string.IsNullOrEmpty(LicenceNotice)) return LicenceNotice!;
-            if (!HasToken) return "Not signed in";
+            if (!HasToken) return Localization.T("Licence.NotSignedIn");
 
             // A licence server that is set but has never sent a game list means the ranges are
             // whatever the installer carried. The tunnel works, so nothing else would say so.
             if (!string.IsNullOrWhiteSpace(LicenceUrl) && ProfileSource == "shipped")
             {
-                return "Signed in - using the installed game list, not the current one";
+                return Localization.T("Licence.UsingInstalledProfile");
             }
-            if (TokenExpiresAt is not { } expiry) return "Signed in";
+            if (TokenExpiresAt is not { } expiry) return Localization.T("Licence.SignedIn");
 
             // Renewal happens on its own at half of remaining life, so an expiry hours away is
             // normal and not something to alarm anybody about. Only say something when it is
             // close enough that the renewal has evidently not been happening.
             var left = expiry - DateTimeOffset.UtcNow;
-            if (left <= TimeSpan.Zero) return "Licence expired - sign in again";
-            if (left < TimeSpan.FromHours(2)) return $"Licence expires in {left.TotalMinutes:F0} min";
-            return $"Signed in, licence valid until {expiry.LocalDateTime:g}";
+            if (left <= TimeSpan.Zero) return Localization.T("Licence.Expired");
+            if (left < TimeSpan.FromHours(2)) return Localization.T("Licence.ExpiresSoon", $"{left.TotalMinutes:F0}");
+            return Localization.T("Licence.ValidUntil", expiry.LocalDateTime.ToString("g"));
         }
     }
 
@@ -193,11 +226,23 @@ public sealed class MainViewModel : INotifyPropertyChanged
             Raise(nameof(ActionButtonText));
             Raise(nameof(IsBusy));
             Raise(nameof(CanPressAction));
+            Raise(nameof(GameText));
         }
     }
 
-    private string _detail = "Starting up...";
-    public string Detail { get => _detail; private set => Set(ref _detail, value); }
+    private string _rawDetail = "Starting up...";
+    public string Detail
+    {
+        get => Localization.LocalizeDetail(_rawDetail, SelectedGame?.DisplayName ?? GameName, RelayName);
+        private set
+        {
+            if (_rawDetail != value)
+            {
+                _rawDetail = value;
+                Raise(nameof(Detail));
+            }
+        }
+    }
 
     // ------------------------------------------------------- configuration state
     //
@@ -290,7 +335,11 @@ public sealed class MainViewModel : INotifyPropertyChanged
         get => _gameRunning;
         private set
         {
-            if (Set(ref _gameRunning, value)) Raise(nameof(GameText));
+            if (Set(ref _gameRunning, value))
+            {
+                Raise(nameof(GameText));
+                Raise(nameof(StatusText));
+            }
         }
     }
 
@@ -304,13 +353,55 @@ public sealed class MainViewModel : INotifyPropertyChanged
         }
     }
 
+    /// <summary>
+    /// Games the user can choose to optimize. Shipped with the standard titles so the dropdown
+    /// is populated immediately; the service expands it when it reads custom profiles from disk.
+    /// </summary>
+    public ObservableCollection<GameOptionItem> AvailableGames { get; } = [
+        new GameOptionItem("cs2", "Counter-Strike 2"),
+        new GameOptionItem("pubg", "PUBG: BATTLEGROUNDS")
+    ];
+
+    private GameOptionItem? _selectedGame;
+
+    /// <summary>
+    /// The game chosen for this session. Null until picked by the user from the dropdown.
+    /// </summary>
+    public GameOptionItem? SelectedGame
+    {
+        get => _selectedGame;
+        set
+        {
+            if (Set(ref _selectedGame, value))
+            {
+                // Clear the validation prompt the instant the user picks a game.
+                if (value is not null && Error == Localization.T("Warning.SelectGame"))
+                {
+                    Error = null;
+                }
+                Raise(nameof(GameText));
+                Raise(nameof(StatusText));
+                Raise(nameof(Detail));
+                Raise(nameof(CanPressAction));
+                if (value is not null)
+                {
+                    _ = _pipe.SelectGameAsync(value.Id);
+                }
+            }
+        }
+    }
+
     private string? _relayName;
     public string? RelayName
     {
         get => _relayName;
         private set
         {
-            if (Set(ref _relayName, value)) Raise(nameof(RelayText));
+            if (Set(ref _relayName, value))
+            {
+                Raise(nameof(RelayText));
+                Raise(nameof(Detail));
+            }
         }
     }
 
@@ -348,12 +439,14 @@ public sealed class MainViewModel : INotifyPropertyChanged
 
     public string StatusText => State switch
     {
-        TunnelState.Disconnected => "Not connected",
-        TunnelState.Connecting => "Connecting...",
-        TunnelState.Connected => "Connected",
-        TunnelState.Reconnecting => "Reconnecting...",
-        TunnelState.Faulted => "Error",
-        _ => "Unknown",
+        TunnelState.Disconnected => Localization.T("Status.Disconnected"),
+        TunnelState.Connecting => Localization.T("Status.Connecting"),
+        TunnelState.Connected => (SelectedGame is not null && !GameRunning)
+            ? Localization.T("Status.ConnectedWaitingGame")
+            : Localization.T("Status.Connected"),
+        TunnelState.Reconnecting => Localization.T("Status.Reconnecting"),
+        TunnelState.Faulted => Localization.T("Status.Error"),
+        _ => Localization.T("Status.Unknown"),
     };
 
     /// <summary>
@@ -369,8 +462,8 @@ public sealed class MainViewModel : INotifyPropertyChanged
     };
 
     public string ActionButtonText => State is TunnelState.Connected or TunnelState.Connecting
-        ? "Disconnect"
-        : "Connect";
+        ? Localization.T("Action.Disconnect")
+        : Localization.T("Action.Connect");
 
     public bool IsBusy => State is TunnelState.Connecting or TunnelState.Reconnecting;
     // Nothing to connect to until a relay and a key exist, so the button is dead until then and
@@ -399,24 +492,59 @@ public sealed class MainViewModel : INotifyPropertyChanged
     /// </summary>
     public string GamePingText => GamePingMs is { } g
         ? (GamePingDirect ? "" : "~") +
-          (GameRegionName is { } region ? $"{g:F0} ms to {region}" : $"{g:F0} ms")
+          (GameRegionName is { } region ? Localization.T("Metrics.ToRegion", $"{g:F0}", region) : $"{g:F0} ms")
         : "-";
 
     public string PingText => PingMs is { } p ? $"{p:F0} ms" : "-";
     public string LossText => LossRatio is { } l ? $"{l * 100:F1}%" : "-";
     public string RelayText => RelayName ?? "-";
-    public string RouteText => ActiveRoutes > 0 ? $"{ActiveRoutes} ranges" : "-";
+    public string RouteText => ActiveRoutes > 0 ? Localization.T("Metrics.Ranges", ActiveRoutes) : "-";
 
-    public string GameText => GameName is null
-        ? "-"
-        : GameRunning ? $"{GameName} is running" : $"{GameName} is not open";
+    public string GameText
+    {
+        get
+        {
+            if (SelectedGame is null) return Localization.T("Game.NoSelected");
+
+            var targetName = SelectedGame.DisplayName;
+            if (GameRunning && (string.IsNullOrEmpty(GameName) || string.Equals(GameName, targetName, StringComparison.OrdinalIgnoreCase)))
+            {
+                return Localization.T("Game.Running", targetName);
+            }
+
+            return State == TunnelState.Connected
+                ? Localization.T("Game.WaitingToLaunch", targetName)
+                : Localization.T("Game.NotOpen", targetName);
+        }
+    }
 
     /// <summary>
     /// Packet counters. Not cosmetic: when the tunnel connects but traffic does not flow, the
     /// first question is always whether the client is sending at all, and this answers it
     /// without attaching a packet capture.
     /// </summary>
-    public string PacketsText => $"{PacketsSent} up / {PacketsReceived} down";
+    public string PacketsText => Localization.T("Metrics.Packets", PacketsSent, PacketsReceived);
+
+    // Localized UI Labels (Instance properties required for XAML data binding)
+#pragma warning disable CA1822
+    public string LabelPingInGame => Localization.T("Label.PingInGame");
+    public string LabelPingToRelay => Localization.T("Label.PingToRelay");
+    public string LabelPacketLoss => Localization.T("Label.PacketLoss");
+    public string LabelRelayServer => Localization.T("Label.RelayServer");
+    public string LabelGame => Localization.T("Label.Game");
+    public string LabelRouting => Localization.T("Label.Routing");
+    public string LabelPackets => Localization.T("Label.Packets");
+    public string SelectGamePlaceholder => Localization.T("Selector.Placeholder");
+    public string NoRelayBannerText => Localization.T("Banner.NoRelay");
+    public string MenuSettingsText => Localization.T("Menu.Settings");
+    public string MenuLanguageText => Localization.T("Menu.Language");
+    public string MenuLanguageViText => Localization.T("Menu.LanguageVi");
+    public string MenuLanguageEnText => Localization.T("Menu.LanguageEn");
+    public string MenuReportLagText => Localization.T("Menu.ReportLag");
+    public string MenuLogsText => Localization.T("Menu.Logs");
+    public string MenuAboutText => Localization.T("Menu.About");
+#pragma warning restore CA1822
+
 
     // ------------------------------------------------------------------- actions
 
@@ -448,7 +576,7 @@ public sealed class MainViewModel : INotifyPropertyChanged
         _teardown = wait;
         try
         {
-            Detail = "Disconnecting...";
+            Detail = Localization.T("Detail.Disconnecting");
             await _pipe.DisconnectTunnelAsync().ConfigureAwait(true);
             await Task.WhenAny(wait.Task, Task.Delay(timeout)).ConfigureAwait(true);
         }
@@ -497,22 +625,32 @@ public sealed class MainViewModel : INotifyPropertyChanged
             }
             else
             {
+                // Refuse to connect without a target game. Without one the service would either
+                // have to guess from running processes or wait indefinitely without knowing which
+                // routes to install.
+                if (SelectedGame is null)
+                {
+                    Error = Localization.T("Warning.SelectGame");
+                    Detail = Localization.T("Detail.SelectGame");
+                    return;
+                }
+
                 _connectInFlight = true;
                 State = TunnelState.Connecting;
 
                 if (profileSync is not null && !string.IsNullOrWhiteSpace(LicenceUrl))
                 {
-                    Detail = "Getting the latest server list...";
+                    Detail = Localization.T("Detail.GettingServerList");
                     // ConfigureAwait(true): this is called from a click on the UI thread, and the
                     // next line raises PropertyChanged - off the UI thread that breaks Avalonia's
                     // bindings in ways that surface later and somewhere else.
                     await profileSync
-                        .SyncAsync(LicenceUrl, DevicePublicKey, "pubg", force: true)
+                        .SyncAsync(LicenceUrl, DevicePublicKey, SelectedGame.Id, force: true)
                         .ConfigureAwait(true);
                 }
 
-                Detail = "Sending the request to the background service...";
-                await _pipe.ConnectTunnelAsync().ConfigureAwait(true);
+                Detail = Localization.T("Detail.SendingRequest");
+                await _pipe.ConnectTunnelAsync(gameId: SelectedGame.Id).ConfigureAwait(true);
             }
         }
         catch (Exception ex)
@@ -542,6 +680,7 @@ public sealed class MainViewModel : INotifyPropertyChanged
     private void OnStatus(StatusMessage status) => Dispatcher.UIThread.Post(() =>
     {
         LastStatus = status;
+        var previousState = _state;
         State = status.State;
 
         // Whoever is closing the app can stop waiting. Faulted counts: the tunnel is not up, and
@@ -552,7 +691,15 @@ public sealed class MainViewModel : INotifyPropertyChanged
             _teardown?.TrySetResult();
         }
         Detail = status.Detail;
-        Error = status.Error;
+
+        // A service heartbeat with no error must not wipe a warning the UI just set
+        // (e.g. "please select a game"). Only adopt a null from the service when the
+        // tunnel state has changed - that invalidates any UI-originated message anyway -
+        // or when the service is reporting an actual error string.
+        if (status.Error is not null || status.State != previousState)
+        {
+            Error = status.Error;
+        }
         PingMs = status.TunnelPingMs;
         GamePingMs = status.GamePingMs;
         GamePingDirect = status.GamePingDirect;
@@ -560,6 +707,33 @@ public sealed class MainViewModel : INotifyPropertyChanged
         LossRatio = status.LossRatio;
         GameRunning = status.GameRunning;
         GameName = status.GameName;
+
+        // Append newly discovered profiles without clearing the collection. Calling Clear() resets
+        // the ComboBox's SelectedItem binding in Avalonia and drops what the user just clicked.
+        if (status.AvailableGames.Count > 0)
+        {
+            foreach (var g in status.AvailableGames)
+            {
+                if (!AvailableGames.Any(x => string.Equals(x.Id, g.Id, StringComparison.OrdinalIgnoreCase)))
+                {
+                    AvailableGames.Add(new GameOptionItem(g.Id, g.Name));
+                }
+            }
+        }
+
+        // Only adopt the service's selection if the user hasn't made one yet (e.g. on first launch).
+        // Once the user picks a game, the UI is authoritative.
+        if (_selectedGame is null && !string.IsNullOrEmpty(status.SelectedGameId))
+        {
+            var current = AvailableGames.FirstOrDefault(g => g.Id.Equals(status.SelectedGameId, StringComparison.OrdinalIgnoreCase));
+            if (current is not null)
+            {
+                _selectedGame = current;
+                Raise(nameof(SelectedGame));
+                Raise(nameof(GameText));
+            }
+        }
+
         RelayName = status.RelayName;
         RelayEndpoints = status.RelayEndpoints;
         Configured = status.Configured;
@@ -607,4 +781,20 @@ public sealed class MainViewModel : INotifyPropertyChanged
     }
 
     private void Raise(string? name) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+}
+
+/// <summary>
+/// A selectable game option in the UI dropdown.
+/// </summary>
+public sealed class GameOptionItem(string id, string displayName)
+{
+    public string Id { get; } = id;
+    public string DisplayName { get; } = displayName;
+
+    public override string ToString() => DisplayName;
+
+    public override bool Equals(object? obj) =>
+        obj is GameOptionItem other && string.Equals(Id, other.Id, StringComparison.OrdinalIgnoreCase);
+
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Id);
 }

--- a/client/src/GamePingBooster.App/Views/MainWindow.axaml
+++ b/client/src/GamePingBooster.App/Views/MainWindow.axaml
@@ -1,4 +1,4 @@
-﻿<views:SurfaceWindow xmlns="https://github.com/avaloniaui"
+<views:SurfaceWindow xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:vm="using:GamePingBooster.App.ViewModels"
         xmlns:views="using:GamePingBooster.App.Views"
@@ -66,11 +66,28 @@
 
     <!-- Header -->
     <Grid Grid.Row="0" ColumnDefinitions="*,Auto">
+      <!-- Game selector -->
+      <ComboBox Grid.Column="0"
+                ItemsSource="{Binding AvailableGames}"
+                SelectedItem="{Binding SelectedGame}"
+                PlaceholderText="{Binding SelectGamePlaceholder}"
+                HorizontalAlignment="Left" VerticalAlignment="Center"
+                MinWidth="180" MaxWidth="280" Height="36"
+                Background="#242424" Foreground="#E0E0E0"
+                BorderThickness="0" CornerRadius="8"
+                ToolTip.Tip="{Binding SelectGamePlaceholder}">
+        <ComboBox.ItemTemplate>
+          <DataTemplate x:DataType="vm:GameOptionItem">
+            <TextBlock Text="{Binding DisplayName}" VerticalAlignment="Center" />
+          </DataTemplate>
+        </ComboBox.ItemTemplate>
+      </ComboBox>
+
       <!--
         Everything that is not Connect lives here. There were three buttons competing with the
         one that matters; now there is one primary action and a menu.
       -->
-      <Button Grid.Column="1" VerticalAlignment="Top"
+      <Button Grid.Column="1" VerticalAlignment="Center"
               Padding="10"
               Background="Transparent" BorderThickness="0"
               ToolTip.Tip="Menu">
@@ -81,11 +98,15 @@
           <MenuFlyout Placement="BottomEdgeAlignedRight" FlyoutPresenterClasses="custom-bg">
             <MenuItem Header="{Binding AccountMenuText}" Click="OnAccountClick"
                       IsVisible="{Binding ShowLicence}" />
-            <MenuItem Header="Settings" Click="OnSettingsClick" />
+            <MenuItem Header="{Binding MenuSettingsText}" Click="OnSettingsClick" />
+            <MenuItem Header="{Binding MenuLanguageText}">
+              <MenuItem Header="{Binding MenuLanguageViText}" Tag="vi" Click="OnLanguageClick" />
+              <MenuItem Header="{Binding MenuLanguageEnText}" Tag="en" Click="OnLanguageClick" />
+            </MenuItem>
             <Separator Background="#242424" />
-            <MenuItem Header="Report lag" Click="OnReportLagClick" />
-            <MenuItem Header="Open logs folder" Click="OnLogsClick" />
-            <MenuItem Header="About" Click="OnAboutClick" />
+            <MenuItem Header="{Binding MenuReportLagText}" Click="OnReportLagClick" />
+            <MenuItem Header="{Binding MenuLogsText}" Click="OnLogsClick" />
+            <MenuItem Header="{Binding MenuAboutText}" Click="OnAboutClick" />
             <!-- Only there when UpdateChecker has found a newer release. -->
             <Separator Background="#242424" IsVisible="{Binding HasUpdate}" />
             <MenuItem Classes="update" Header="{Binding UpdateMenuText}" Click="OnUpdateClick"
@@ -97,23 +118,27 @@
 
     <!-- Primary status -->
     <Border Grid.Row="1" Classes="card" Margin="0,20,0,0">
-      <StackPanel Spacing="8" HorizontalAlignment="Center">
-        <StackPanel Orientation="Horizontal" Spacing="10" HorizontalAlignment="Center">
-          <Ellipse Width="12" Height="12" VerticalAlignment="Center"
-                   Fill="{Binding StatusBrush}" />
-          <TextBlock Text="{Binding StatusText}"
-                     Foreground="{Binding StatusBrush}"
-                     FontSize="22" FontWeight="Bold" />
+      <!-- Grid lets the progress bar sit at the bottom as an overlay without adding to the card
+           height - a StackPanel would push the details panel down and clip "Ping in game". -->
+      <Grid RowDefinitions="*,Auto">
+        <StackPanel Grid.Row="0" Spacing="8" HorizontalAlignment="Center">
+          <StackPanel Orientation="Horizontal" Spacing="10" HorizontalAlignment="Center">
+            <Ellipse Width="12" Height="12" VerticalAlignment="Center"
+                     Fill="{Binding StatusBrush}" />
+            <TextBlock Text="{Binding StatusText}"
+                       Foreground="{Binding StatusBrush}"
+                       FontSize="22" FontWeight="Bold" />
+          </StackPanel>
+
+          <TextBlock Text="{Binding Detail}"
+                     Foreground="#ababab" FontSize="12"
+                     TextWrapping="Wrap" TextAlignment="Center"
+                     MaxWidth="320" />
         </StackPanel>
 
-        <TextBlock Text="{Binding Detail}"
-                   Foreground="#ababab" FontSize="12"
-                   TextWrapping="Wrap" TextAlignment="Center"
-                   MaxWidth="320" />
-
-        <ProgressBar IsIndeterminate="True" Height="3" Margin="0,4,0,0"
+        <ProgressBar Grid.Row="1" IsIndeterminate="True" Height="3" Margin="0,8,0,0"
                      IsVisible="{Binding IsBusy}" />
-      </StackPanel>
+      </Grid>
     </Border>
 
     <!-- Details -->
@@ -123,25 +148,25 @@
              figure is the one a tester read as his game ping, saw 23 ms, and then played at
              70-80 - it is half the path and it must not sit at the top wearing that meaning. -->
         <Grid ColumnDefinitions="*,Auto" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto" >
-          <TextBlock Grid.Row="0" Grid.Column="0" Classes="label" Text="Ping in game" />
+          <TextBlock Grid.Row="0" Grid.Column="0" Classes="label" Text="{Binding LabelPingInGame}" />
           <TextBlock Grid.Row="0" Grid.Column="1" Classes="value" Text="{Binding GamePingText}" />
 
-          <TextBlock Grid.Row="1" Grid.Column="0" Classes="label" Text="Ping to relay" Margin="0,10,0,0" />
+          <TextBlock Grid.Row="1" Grid.Column="0" Classes="label" Text="{Binding LabelPingToRelay}" Margin="0,10,0,0" />
           <TextBlock Grid.Row="1" Grid.Column="1" Classes="value" Text="{Binding PingText}" Margin="0,10,0,0" />
 
-          <TextBlock Grid.Row="2" Grid.Column="0" Classes="label" Text="Packet loss" Margin="0,10,0,0" />
+          <TextBlock Grid.Row="2" Grid.Column="0" Classes="label" Text="{Binding LabelPacketLoss}" Margin="0,10,0,0" />
           <TextBlock Grid.Row="2" Grid.Column="1" Classes="value" Text="{Binding LossText}" Margin="0,10,0,0" />
 
-          <TextBlock Grid.Row="3" Grid.Column="0" Classes="label" Text="Relay server" Margin="0,10,0,0" />
+          <TextBlock Grid.Row="3" Grid.Column="0" Classes="label" Text="{Binding LabelRelayServer}" Margin="0,10,0,0" />
           <TextBlock Grid.Row="3" Grid.Column="1" Classes="value" Text="{Binding RelayText}" Margin="0,10,0,0" />
 
-          <TextBlock Grid.Row="4" Grid.Column="0" Classes="label" Text="Game" Margin="0,10,0,0" />
+          <TextBlock Grid.Row="4" Grid.Column="0" Classes="label" Text="{Binding LabelGame}" Margin="0,10,0,0" />
           <TextBlock Grid.Row="4" Grid.Column="1" Classes="value" Text="{Binding GameText}" Margin="0,10,0,0" />
 
-          <TextBlock Grid.Row="5" Grid.Column="0" Classes="label" Text="Routing" Margin="0,10,0,0" />
+          <TextBlock Grid.Row="5" Grid.Column="0" Classes="label" Text="{Binding LabelRouting}" Margin="0,10,0,0" />
           <TextBlock Grid.Row="5" Grid.Column="1" Classes="value" Text="{Binding RouteText}" Margin="0,10,0,0" />
 
-          <TextBlock Grid.Row="6" Grid.Column="0" Classes="label" Text="Packets" Margin="0,10,0,0" />
+          <TextBlock Grid.Row="6" Grid.Column="0" Classes="label" Text="{Binding LabelPackets}" Margin="0,10,0,0" />
           <TextBlock Grid.Row="6" Grid.Column="1" Classes="value" Text="{Binding PacketsText}" Margin="0,10,0,0" />
         </Grid>
       </Border>
@@ -163,7 +188,7 @@
               Background="#20252b" CornerRadius="8" Padding="12" Margin="0,0,0,12"
               IsVisible="{Binding NeedsSetup}">
         <TextBlock Foreground="#869bb3" FontSize="12" TextWrapping="Wrap"
-                   Text="No relay configured yet. Open Settings and enter your relay's address and key." />
+                   Text="{Binding NoRelayBannerText}" />
       </Border>
 
       <Button Grid.Row="1" Grid.ColumnSpan="2"

--- a/client/src/GamePingBooster.App/Views/MainWindow.axaml.cs
+++ b/client/src/GamePingBooster.App/Views/MainWindow.axaml.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
@@ -40,6 +40,14 @@ public partial class MainWindow : SurfaceWindow
         };
         dialog.Attach(_pipe);
         await dialog.ShowDialog(this);
+    }
+
+    // Language is encoded in the Tag of the menu item so this single handler covers all options.
+    private void OnLanguageClick(object? sender, RoutedEventArgs e)
+    {
+        var tag = (sender as MenuItem)?.Tag as string;
+        var language = tag == "en" ? AppLanguage.English : AppLanguage.Vietnamese;
+        Localization.SetLanguage(language);
     }
 
     /// <summary>

--- a/client/src/GamePingBooster.App/Views/ReportLagWindow.axaml
+++ b/client/src/GamePingBooster.App/Views/ReportLagWindow.axaml
@@ -51,18 +51,18 @@
         <Border Background="#1E293B" CornerRadius="8" Padding="14">
           <StackPanel Spacing="8">
             <TextBlock Classes="label" Text="WHAT IS MEASURED AND SENT" />
-            <TextBlock Classes="item" Text="• Response time, jitter and packet loss to your home router, your internet provider's network, and the relay." />
-            <TextBlock Classes="item" Text="• The network path to the relay, which includes your router's local address and your provider's router addresses." />
-            <TextBlock Classes="item" Text="• Your public IP address, the relay in use, the app version, and whether the game is running." />
-            <TextBlock Classes="item" Text="• The ping and packet loss figures the app is already showing you." />
+            <TextBlock Classes="item" Text="- Response time, jitter and packet loss to your home router, your internet provider's network, and the relay." />
+            <TextBlock Classes="item" Text="- The network path to the relay, which includes your router's local address and your provider's router addresses." />
+            <TextBlock Classes="item" Text="- Your public IP address, the relay in use, the app version, and whether the game is running." />
+            <TextBlock Classes="item" Text="- The ping and packet loss figures the app is already showing you." />
           </StackPanel>
         </Border>
 
         <Border Background="#1E293B" CornerRadius="8" Padding="14">
           <StackPanel Spacing="8">
             <TextBlock Classes="label" Text="WHAT IS NOT SENT" />
-            <TextBlock Classes="item" Text="• Nothing about what you do online — no browsing, no file names, no message or game content." />
-            <TextBlock Classes="item" Text="• No password, no licence key, no payment detail." />
+            <TextBlock Classes="item" Text="- Nothing about what you do online: no browsing, no file names, no message or game content." />
+            <TextBlock Classes="item" Text="- No password, no licence key, no payment detail." />
             <TextBlock Classes="item" Text="Your connection stays up throughout. Nothing is disconnected and no setting is changed." />
           </StackPanel>
         </Border>
@@ -71,7 +71,7 @@
           <TextBlock Classes="label" Text="ANYTHING YOU WANT TO ADD (OPTIONAL)" />
           <TextBox Name="CommentBox" MaxLength="2000" Height="60"
                    AcceptsReturn="True" TextWrapping="Wrap"
-                   Watermark="e.g. it spikes every few minutes during a match"
+                   PlaceholderText="e.g. it spikes every few minutes during a match"
                    Background="#0F172A" Foreground="#E2E8F0" BorderBrush="#334155" />
         </StackPanel>
 

--- a/client/src/GamePingBooster.App/Views/SystemTray.cs
+++ b/client/src/GamePingBooster.App/Views/SystemTray.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using Avalonia.Controls;
 using Avalonia.Platform;
+using GamePingBooster.App.Services;
 using GamePingBooster.App.ViewModels;
 
 namespace GamePingBooster.App.Views;
@@ -26,6 +27,7 @@ public sealed class SystemTray : IDisposable
     private readonly TrayIcon _icon;
     private readonly MainWindow _window;
     private readonly MainViewModel _vm;
+    private readonly Action _languageHandler;
 
     /// <param name="exit">
     /// The app's full exit: tunnel down first, then shutdown. Not desktop.Shutdown(), which is a
@@ -45,10 +47,10 @@ public sealed class SystemTray : IDisposable
             ToolTipText = ToolTipText(),
         };
 
-        var show = new NativeMenuItem("Show Game Ping Booster");
+        var show = new NativeMenuItem(Localization.T("Tray.Show"));
         show.Click += (_, _) => _window.RestoreFromTray();
 
-        var quit = new NativeMenuItem("Exit");
+        var quit = new NativeMenuItem(Localization.T("Tray.Exit"));
         quit.Click += (_, _) =>
         {
             // Gone the moment it is pressed. Teardown takes seconds on a bad day and there is no
@@ -57,10 +59,20 @@ public sealed class SystemTray : IDisposable
             exit();
         };
 
-        var menu = new NativeMenu();
-        menu.Add(show);
-        menu.Add(new NativeMenuItemSeparator());
-        menu.Add(quit);
+        _languageHandler = () =>
+        {
+            show.Header = Localization.T("Tray.Show");
+            quit.Header = Localization.T("Tray.Exit");
+            _icon.ToolTipText = ToolTipText();
+        };
+        Localization.LanguageChanged += _languageHandler;
+
+        var menu = new NativeMenu
+        {
+            show,
+            new NativeMenuItemSeparator(),
+            quit
+        };
         _icon.Menu = menu;
 
         // Left click: what every other icon in the notification area answers to. Restores rather
@@ -109,6 +121,7 @@ public sealed class SystemTray : IDisposable
     public void Dispose()
     {
         _vm.PropertyChanged -= OnViewModelChanged;
+        Localization.LanguageChanged -= _languageHandler;
         _icon.IsVisible = false;
         _icon.Dispose();
     }

--- a/client/src/GamePingBooster.Core/Ipc/IpcContracts.cs
+++ b/client/src/GamePingBooster.Core/Ipc/IpcContracts.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json.Serialization;
+using System.Text.Json.Serialization;
 
 namespace GamePingBooster.Core.Ipc;
 
@@ -68,7 +68,7 @@ public sealed class CommandMessage
     /// <summary>Relay id to use, e.g. "sg-1". Empty means let the service pick by ping.</summary>
     [JsonPropertyName("relayId")] public string? RelayId { get; set; }
 
-    /// <summary>Id of the game to accelerate, e.g. "pubg".</summary>
+    /// <summary>Id of the game to optimize, e.g. "cs2", "pubg".</summary>
     [JsonPropertyName("gameId")] public string? GameId { get; set; }
 
     // ------------------------------------------------------------------ set-token
@@ -216,6 +216,12 @@ public sealed class StatusMessage
     /// <summary>Whether a game process is running - this drives route install/removal.</summary>
     [JsonPropertyName("gameRunning")] public bool GameRunning { get; set; }
     [JsonPropertyName("gameName")] public string? GameName { get; set; }
+
+    /// <summary>Games available in the loaded profile, for selection in the UI.</summary>
+    [JsonPropertyName("availableGames")] public List<GameInfoItem> AvailableGames { get; set; } = [];
+
+    /// <summary>The game id selected by the user, or null if no game has been selected yet.</summary>
+    [JsonPropertyName("selectedGameId")] public string? SelectedGameId { get; set; }
 
     /// <summary>Number of routes currently installed in the Windows routing table.</summary>
     [JsonPropertyName("activeRoutes")] public int ActiveRoutes { get; set; }
@@ -365,6 +371,15 @@ public sealed class StatusMessage
 }
 
 /// <summary>
+/// A summary of a game declared in the active profile bundle.
+/// </summary>
+public sealed class GameInfoItem
+{
+    [JsonPropertyName("id")] public string Id { get; set; } = "";
+    [JsonPropertyName("name")] public string Name { get; set; } = "";
+}
+
+/// <summary>
 /// Source-generated JSON, required for Native AOT (the reflection-based serializer is trimmed away).
 /// </summary>
 [JsonSourceGenerationOptions(
@@ -372,4 +387,6 @@ public sealed class StatusMessage
     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
 [JsonSerializable(typeof(CommandMessage))]
 [JsonSerializable(typeof(StatusMessage))]
+[JsonSerializable(typeof(GameInfoItem))]
+[JsonSerializable(typeof(List<GameInfoItem>))]
 public partial class IpcJsonContext : JsonSerializerContext;

--- a/client/src/GamePingBooster.Core/Native/IpHelperInterop.cs
+++ b/client/src/GamePingBooster.Core/Native/IpHelperInterop.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Net.Sockets;
 using System.Runtime.InteropServices;
 
 namespace GamePingBooster.Core.Native;
@@ -68,7 +69,7 @@ public static class IpHelperInterop
     /// </summary>
     public static uint? BestInterfaceFor(IPAddress destination)
     {
-        if (destination.AddressFamily != System.Net.Sockets.AddressFamily.InterNetwork) return null;
+        if (destination.AddressFamily != AddressFamily.InterNetwork) return null;
 
         var bytes = destination.GetAddressBytes();
         var address = new SockAddrIn

--- a/client/src/GamePingBooster.Core/Profiles/GameProfile.cs
+++ b/client/src/GamePingBooster.Core/Profiles/GameProfile.cs
@@ -4,8 +4,8 @@ namespace GamePingBooster.Core.Profiles;
 
 /// <summary>
 /// The profile is the data that decides which IP ranges get routed, for which game, through
-/// which relay. It is fetched from a server (profiles/pubg-vn.json) rather than hard-coded, so
-/// when PUBG changes IP ranges only a JSON file needs updating - no new client release.
+/// which relay. It is fetched from a server or loaded locally (profiles/*.json) rather than hard-coded, so
+/// when games change IP ranges only a JSON file needs updating - no new client release.
 /// </summary>
 public sealed class ProfileBundle
 {
@@ -24,8 +24,8 @@ public sealed class GameEntry
     [JsonPropertyName("name")] public string Name { get; set; } = "";
 
     /// <summary>
-    /// Process names used to detect that the game is running. For PUBG that is TslGame.exe
-    /// (the actual game process) plus PUBG.exe / TslGame_BE.exe (launcher, BattlEye shim).
+    /// Process names used to detect that the game is running. Examples: cs2.exe for CS2;
+    /// TslGame.exe plus PUBG.exe / TslGame_BE.exe for PUBG.
     /// This only enumerates processes the way Task Manager does - it never opens the game,
     /// reads its memory, or touches its files.
     /// </summary>
@@ -49,8 +49,7 @@ public sealed class GameEntry
     ///
     /// Single addresses only, as "a.b.c.d" or "a.b.c.d/32". Anything wider is refused by
     /// <see cref="LobbyRoutes"/>, because these stay routed while the game is closed and a range
-    /// would pull other programs' traffic through the relay all day. For PUBG these are the static
-    /// anycast pair of its AWS Global Accelerator, which belong to that accelerator alone.
+    /// would pull other programs' traffic through the relay all day.
     ///
     /// Absent from a profile means no lobby routes, and an older client simply ignores the field.
     /// The licence server does not send it yet: its profile is assembled from the database, not
@@ -66,18 +65,17 @@ public sealed class RegionEntry
 
     /// <summary>
     /// Destination ranges routed through the tunnel, in CIDR form. This list must stay NARROW -
-    /// see docs/pubg-ip-ranges.md: routing all of AWS ap-southeast-1 would drag thousands of
-    /// unrelated services through the relay.
+    /// routing entire cloud provider regions would drag thousands of unrelated services through the relay.
     /// </summary>
     [JsonPropertyName("cidrs")] public List<string> Cidrs { get; set; } = [];
 
     /// <summary>
     /// Stable addresses that stand in for this region when its latency has to be measured.
     ///
-    /// For PUBG these are the endpoints the game itself probes on UDP 8081 to choose a
-    /// datacentre. They are the right stand-in for three reasons:
-    /// they are inside the region, they recur across sessions (gameplay servers do not), and
-    /// they answer ICMP, so measuring them needs no cooperation from anyone.
+    /// These are endpoints the game or coordinator probes to choose a datacentre.
+    /// They are the right stand-in for three reasons: they are inside the region, they recur
+    /// across sessions (gameplay servers do not), and they answer ICMP, so measuring them
+    /// needs no cooperation from anyone.
     ///
     /// Deliberately NOT covered by <see cref="Cidrs"/>. A landmark that went through the tunnel
     /// would make the game measure some regions through the relay and the rest over the player's

--- a/client/src/GamePingBooster.ProtocolCheck/Program.cs
+++ b/client/src/GamePingBooster.ProtocolCheck/Program.cs
@@ -1,8 +1,9 @@
-﻿using System.Buffers.Binary;
+using System.Buffers.Binary;
 using System.Globalization;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
+using GamePingBooster.Core.Profiles;
 using GamePingBooster.Core.Protocol;
 
 namespace GamePingBooster.ProtocolCheck;
@@ -116,16 +117,25 @@ internal static class Program
             {"schemaVersion":1,"games":[{"id":"pubg","name":"PUBG","processNames":["TslGame"],"regions":[]}],"relays":[]}
             """;
 
-        var parsed = System.Text.Json.JsonSerializer.Deserialize(withField,
-            GamePingBooster.Core.Profiles.ProfileJsonContext.Default.ProfileBundle)!;
+        var parsed = JsonSerializer.Deserialize(withField,
+            ProfileJsonContext.Default.ProfileBundle)!;
         Check("profile: lobbyAddresses is read under that exact name",
             parsed.Games[0].LobbyAddresses.Count == 2,
             $"got {parsed.Games[0].LobbyAddresses.Count} address(es) - the JSON name and GameEntry disagree");
 
-        var old = System.Text.Json.JsonSerializer.Deserialize(withoutField,
-            GamePingBooster.Core.Profiles.ProfileJsonContext.Default.ProfileBundle)!;
+        var old = JsonSerializer.Deserialize(withoutField,
+            ProfileJsonContext.Default.ProfileBundle)!;
         Check("profile: a profile without lobbyAddresses gives an empty list, not null",
             old.Games[0].LobbyAddresses is { Count: 0 }, "the licence server does not send the field yet");
+
+        const string cs2Sample = """
+            {"schemaVersion":1,"games":[{"id":"cs2","name":"Counter-Strike 2","processNames":["cs2.exe"],"regions":[]}],"relays":[]}
+            """;
+        var cs2Parsed = JsonSerializer.Deserialize(cs2Sample,
+            ProfileJsonContext.Default.ProfileBundle)!;
+        Check("profile: CS2 game profile parses with processNames",
+            cs2Parsed.Games.Count == 1 && cs2Parsed.Games[0].Id == "cs2" && cs2Parsed.Games[0].ProcessNames.Contains("cs2.exe"),
+            "CS2 profile schema parsing failed");
 
         var relays = new[] { "203.0.113.10:51820" };
         var landmarks = new[] { "20.43.187.66" };
@@ -273,7 +283,7 @@ internal static class Program
             pkt.Length == GpbProtocol.HandshakeRespV2Len,
             $"got {pkt.Length}, want {GpbProtocol.HandshakeRespV2Len}");
 
-        if (!GpbProtocol.TryParseHandshakeResp(psk, pkt, ReadOnlySpan<byte>.Empty, out var result))
+        if (!GpbProtocol.TryParseHandshakeResp(psk, pkt, [], out var result))
         {
             Fail("version-mismatch answer", "the client cannot parse it, so it would report a timeout instead");
             return;
@@ -509,7 +519,7 @@ internal static class Program
     private const int ReqTokenSigOffset = ReqTokenOffset + GpbProtocol.TokenLen;
 
     private static ulong ReadUInt64BE(ReadOnlySpan<byte> b, int offset) =>
-        System.Buffers.Binary.BinaryPrimitives.ReadUInt64BigEndian(b.Slice(offset, 8));
+        BinaryPrimitives.ReadUInt64BigEndian(b.Slice(offset, 8));
 
     /// <summary>
     /// Emits a token-mode HandshakeReq for the Go side to verify.

--- a/client/src/GamePingBooster.Service/FileLog.cs
+++ b/client/src/GamePingBooster.Service/FileLog.cs
@@ -1,4 +1,6 @@
 using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.IO;
 using System.Text;
 
 namespace GamePingBooster.Service;
@@ -41,12 +43,12 @@ internal sealed class FileLog : IDisposable
     private bool _disposed;
 
     /// <summary>Where the log is being written, for the startup banner. Null if unavailable.</summary>
-    public string? Path { get; }
+    public string? LogFilePath { get; }
 
     public FileLog(string? directory = null)
     {
-        _directory = directory ?? System.IO.Path.Combine(ServiceConfig.DefaultDirectory, "logs");
-        _currentPath = System.IO.Path.Combine(_directory, "gpb-service.log");
+        _directory = directory ?? Path.Combine(ServiceConfig.DefaultDirectory, "logs");
+        _currentPath = Path.Combine(_directory, "gpb-service.log");
 
         try
         {
@@ -57,12 +59,12 @@ internal sealed class FileLog : IDisposable
             {
                 probe.Flush();
             }
-            Path = _currentPath;
+            LogFilePath = _currentPath;
         }
-        catch (Exception)
+        catch (Exception ex)
         {
-            // No log file available. The service still runs; it simply has nothing to write to.
-            return;
+            // Logging is disabled. Calls to Log will drop harmlessly onto the floor.
+            Trace.WriteLine($"FileLog could not initialise {_currentPath}: {ex.Message}");
         }
 
         _writer = new Thread(WriterLoop)
@@ -147,16 +149,16 @@ internal sealed class FileLog : IDisposable
             var info = new FileInfo(_currentPath);
             if (!info.Exists || info.Length < MaxFileBytes) return;
 
-            var oldest = System.IO.Path.Combine(_directory, $"gpb-service.{KeepFiles}.log");
+            var oldest = Path.Combine(_directory, $"gpb-service.{KeepFiles}.log");
             if (File.Exists(oldest)) File.Delete(oldest);
 
             for (var i = KeepFiles - 1; i >= 1; i--)
             {
-                var from = System.IO.Path.Combine(_directory, $"gpb-service.{i}.log");
-                var to = System.IO.Path.Combine(_directory, $"gpb-service.{i + 1}.log");
+                var from = Path.Combine(_directory, $"gpb-service.{i}.log");
+                var to = Path.Combine(_directory, $"gpb-service.{i + 1}.log");
                 if (File.Exists(from)) File.Move(from, to, overwrite: true);
             }
-            File.Move(_currentPath, System.IO.Path.Combine(_directory, "gpb-service.1.log"), overwrite: true);
+            File.Move(_currentPath, Path.Combine(_directory, "gpb-service.1.log"), overwrite: true);
         }
         catch (IOException)
         {

--- a/client/src/GamePingBooster.Service/Ipc/PipeServer.cs
+++ b/client/src/GamePingBooster.Service/Ipc/PipeServer.cs
@@ -1,4 +1,4 @@
-﻿using System.IO.Pipes;
+using System.IO.Pipes;
 using System.Security.AccessControl;
 using System.Security.Principal;
 using System.Text;
@@ -152,6 +152,11 @@ internal sealed class PipeServer
                 break;
 
             case "status":
+                await PushAsync(_engine.Snapshot()).ConfigureAwait(false);
+                break;
+
+            case "select-game":
+                _engine.SetSelectedGame(cmd.GameId);
                 await PushAsync(_engine.Snapshot()).ConfigureAwait(false);
                 break;
 

--- a/client/src/GamePingBooster.Service/Network/GameProcessWatcher.cs
+++ b/client/src/GamePingBooster.Service/Network/GameProcessWatcher.cs
@@ -10,13 +10,20 @@ namespace GamePingBooster.Service.Network;
 /// anything. That is a hard constraint of this project and the reason BattlEye has nothing to
 /// object to.
 ///
-/// Why watch at all: PUBG's IP ranges live on AWS/Azure alongside thousands of other services.
-/// Leaving the routes in place permanently would drag unrelated traffic through the relay.
+/// Why watch at all: Game server IP ranges (e.g. PUBG on AWS/Azure, Valve SDR relays) live
+/// alongside thousands of other services. Leaving the routes in place permanently would drag
+/// unrelated traffic through the relay.
 /// </summary>
-internal sealed class GameProcessWatcher : IDisposable
+internal sealed class GameProcessWatcher(IEnumerable<string> processNames, TimeSpan? interval = null) : IDisposable
 {
-    private readonly string[] _processNames;
-    private readonly TimeSpan _interval;
+    private readonly string[] _processNames =
+    [
+        .. processNames
+            .Select(n => n.EndsWith(".exe", StringComparison.OrdinalIgnoreCase) ? n[..^4] : n)
+            .Where(n => n.Length > 0)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+    ];
+    private readonly TimeSpan _interval = interval ?? TimeSpan.FromSeconds(2);
     private readonly CancellationTokenSource _cts = new();
     private Task? _loop;
 
@@ -25,17 +32,6 @@ internal sealed class GameProcessWatcher : IDisposable
 
     public bool IsGameRunning { get; private set; }
     public string? RunningProcessName { get; private set; }
-
-    public GameProcessWatcher(IEnumerable<string> processNames, TimeSpan? interval = null)
-    {
-        // Process.GetProcessesByName expects names WITHOUT the .exe suffix.
-        _processNames = processNames
-            .Select(n => n.EndsWith(".exe", StringComparison.OrdinalIgnoreCase) ? n[..^4] : n)
-            .Where(n => n.Length > 0)
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToArray();
-        _interval = interval ?? TimeSpan.FromSeconds(2);
-    }
 
     public void Start()
     {
@@ -51,7 +47,7 @@ internal sealed class GameProcessWatcher : IDisposable
             {
                 var found = FindRunningGame();
                 var running = found is not null;
-                if (running != IsGameRunning)
+                if (running != IsGameRunning || (running && !string.Equals(found, RunningProcessName, StringComparison.OrdinalIgnoreCase)))
                 {
                     IsGameRunning = running;
                     RunningProcessName = found;

--- a/client/src/GamePingBooster.Service/Network/RouteManager.cs
+++ b/client/src/GamePingBooster.Service/Network/RouteManager.cs
@@ -56,7 +56,7 @@ internal sealed class RouteManager
     /// Assigns the inner IP and MTU to the virtual adapter. Call this after the relay has
     /// handed out an address during the handshake.
     /// </summary>
-    public void ConfigureAdapter(uint tunInterfaceIndex, IPAddress innerIp, int prefixLength, int mtu)
+    public static void ConfigureAdapter(uint tunInterfaceIndex, IPAddress innerIp, int prefixLength, int mtu)
     {
         var mask = PrefixLengthToMask(prefixLength);
 
@@ -179,15 +179,15 @@ internal sealed class RouteManager
         // Same reasoning as PinRelayRoute: clear any leftover entry first so `add` cannot fail
         // on a duplicate. Two netsh invocations for the whole batch, not two per route.
         RunNetshScript(
-            fresh.Select(cidr =>
-                $"interface ipv4 delete route prefix={cidr} interface={tunInterfaceIndex} store=active").ToList(),
+            [.. fresh.Select(cidr =>
+                $"interface ipv4 delete route prefix={cidr} interface={tunInterfaceIndex} store=active")],
             ignoreErrors: true);
 
         // Record them before the adds run, not after: if one fails partway some routes are
         // already in the table, and teardown must still know to remove them.
         _installedPrefixes.AddRange(fresh);
 
-        // One process per route so each exit code is attributable. A real PUBG profile is a few
+        // One process per route so each exit code is attributable. A game profile is typically a few
         // dozen prefixes, so this costs a second or two - once, when the game starts. Worth it:
         // a route that silently fails to install looks exactly like a relay that is down.
         foreach (var cidr in fresh)
@@ -202,9 +202,8 @@ internal sealed class RouteManager
         if (_installedPrefixes.Count == 0) return;
 
         var commands = _installedPrefixes
-            .Select(cidr => $"interface ipv4 delete route prefix={cidr} interface={tunInterfaceIndex} store=active")
-            .ToList();
-        RunNetshScript(commands, ignoreErrors: true);
+            .Select(cidr => $"interface ipv4 delete route prefix={cidr} interface={tunInterfaceIndex} store=active");
+        RunNetshScript([.. commands], ignoreErrors: true);
         _installedPrefixes.Clear();
     }
 
@@ -239,8 +238,8 @@ internal sealed class RouteManager
         if (fresh.Count == 0) return;
 
         RunNetshScript(
-            fresh.Select(prefix =>
-                $"interface ipv4 delete route prefix={prefix} interface={tunInterfaceIndex} store=active").ToList(),
+            [.. fresh.Select(prefix =>
+                $"interface ipv4 delete route prefix={prefix} interface={tunInterfaceIndex} store=active")],
             ignoreErrors: true);
 
         _lobbyPrefixes.AddRange(fresh);
@@ -400,7 +399,7 @@ internal sealed class RouteManager
     /// an earlier failure is invisible here. Only use this where failures are expected and
     /// ignored, or where a separate read-back confirms the result.
     /// </summary>
-    private static void RunNetshScript(IReadOnlyCollection<string> commands, bool ignoreErrors = false)
+    private static void RunNetshScript(List<string> commands, bool ignoreErrors = false)
     {
         if (commands.Count == 0) return;
 
@@ -420,7 +419,7 @@ internal sealed class RouteManager
     }
 
     private static void RunNetshCore(
-        string fileName, string arguments, IReadOnlyCollection<string> commands, bool ignoreErrors)
+        string fileName, string arguments, List<string> commands, bool ignoreErrors)
     {
         using var proc = Process.Start(new ProcessStartInfo
         {

--- a/client/src/GamePingBooster.Service/Program.cs
+++ b/client/src/GamePingBooster.Service/Program.cs
@@ -1,4 +1,4 @@
-﻿using System.ServiceProcess;
+using System.ServiceProcess;
 using GamePingBooster.Service.Ipc;
 using GamePingBooster.Service.Tunnel;
 
@@ -79,7 +79,7 @@ public static class Program
             fileLog.Write(message);
         }
 
-        if (fileLog.Path is not null) Console.WriteLine($"Logging to {fileLog.Path}");
+        if (fileLog.LogFilePath is not null) Console.WriteLine($"Logging to {fileLog.LogFilePath}");
 
         try
         {
@@ -102,7 +102,7 @@ public static class Program
     internal static async Task RunAsync(Action<string> log, CancellationToken ct)
     {
         var config = ServiceConfig.Load();
-        log($"Configuration loaded. Default game: {config.DefaultGameId}, adapter: {config.AdapterName}");
+        log($"Configuration loaded. Default game: {config.DefaultGameId ?? "none"}, adapter: {config.AdapterName}");
 
         await using var engine = new TunnelEngine(config, log);
 

--- a/client/src/GamePingBooster.Service/ServiceConfig.cs
+++ b/client/src/GamePingBooster.Service/ServiceConfig.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace GamePingBooster.Service;
@@ -13,8 +13,11 @@ public sealed class ServiceConfig
     /// <summary>URL to fetch the profile (game IP ranges plus relay list). Empty = local file only.</summary>
     [JsonPropertyName("profileUrl")] public string? ProfileUrl { get; set; }
 
-    /// <summary>Path to the local profile file, used offline or when the fetch fails.</summary>
-    [JsonPropertyName("profilePath")] public string ProfilePath { get; set; } = "profiles/pubg-vn.json";
+    /// <summary>Path to the local profile file or directory containing profiles, used offline or when the fetch fails.</summary>
+    [JsonPropertyName("profilePath")] public string ProfilePath { get; set; } = "profiles";
+
+    /// <summary>Optional list of profile file paths to load and merge.</summary>
+    [JsonPropertyName("profilePaths")] public List<string> ProfilePaths { get; set; } = [];
 
     /// <summary>Pre-shared key; must match /etc/gpb/psk on the relay.</summary>
     [JsonPropertyName("psk")] public string Psk { get; set; } = "";
@@ -60,8 +63,8 @@ public sealed class ServiceConfig
     [JsonIgnore]
     public bool HasKey => !string.IsNullOrWhiteSpace(Psk);
 
-    /// <summary>Default game id.</summary>
-    [JsonPropertyName("defaultGameId")] public string DefaultGameId { get; set; } = "pubg";
+    /// <summary>Optional default game id.</summary>
+    [JsonPropertyName("defaultGameId")] public string? DefaultGameId { get; set; }
 
     /// <summary>Virtual adapter name as shown in Network Connections.</summary>
     [JsonPropertyName("adapterName")] public string AdapterName { get; set; } = "Game Ping Booster";

--- a/client/src/GamePingBooster.Service/TokenStore.cs
+++ b/client/src/GamePingBooster.Service/TokenStore.cs
@@ -1,4 +1,5 @@
 using System.Buffers.Binary;
+using System.IO;
 using System.Security.Cryptography;
 using GamePingBooster.Core.Protocol;
 
@@ -30,12 +31,12 @@ internal static class TokenStore
     /// <summary>See the note on DeviceIdentity.Entropy: a domain separator, not a secret.</summary>
     private static readonly byte[] Entropy = "GamePingBooster.LicenceToken.v1"u8.ToArray();
 
-    private static string Path => System.IO.Path.Combine(ServiceConfig.DefaultDirectory, FileName);
+    private static string FilePath => Path.Combine(ServiceConfig.DefaultDirectory, FileName);
 
     /// <summary>The stored token, or null when there is none or it could not be read.</summary>
     public static byte[]? Load(Action<string> log)
     {
-        var path = Path;
+        var path = FilePath;
         if (!File.Exists(path)) return null;
 
         try
@@ -79,9 +80,9 @@ internal static class TokenStore
 
             // Temporary file then replace, as everything else here does: a half-written token is
             // a client that cannot connect until it signs in again.
-            var tmp = Path + ".tmp";
+            var tmp = FilePath + ".tmp";
             File.WriteAllBytes(tmp, blob);
-            File.Move(tmp, Path, overwrite: true);
+            File.Move(tmp, FilePath, overwrite: true);
             return true;
         }
         catch (Exception ex)
@@ -95,7 +96,7 @@ internal static class TokenStore
     {
         try
         {
-            if (File.Exists(Path)) File.Delete(Path);
+            if (File.Exists(FilePath)) File.Delete(FilePath);
         }
         catch (Exception ex)
         {

--- a/client/src/GamePingBooster.Service/Tunnel/LandmarkProbe.cs
+++ b/client/src/GamePingBooster.Service/Tunnel/LandmarkProbe.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Net;
 using System.Net.NetworkInformation;
 using GamePingBooster.Core.Profiles;
@@ -7,11 +8,12 @@ namespace GamePingBooster.Service.Tunnel;
 /// <summary>
 /// Which datacentre the game is going to put this player in, measured rather than assumed.
 ///
-/// PUBG decides that for itself: before a match it probes one endpoint per Azure region on UDP
-/// 8081 and picks the nearest. Those endpoints are stable across sessions - unlike gameplay
-/// servers, which are allocated per match and never repeat - so they can be written into the
-/// profile as a <see cref="RegionEntry.Landmarks"/> list and used as a stand-in for the region
-/// itself. They sit in the region they represent and they answer ICMP, which is all this needs.
+/// Online games decide that for themselves: before a match PUBG probes one endpoint per Azure
+/// region on UDP 8081, Valve SDR checks regional coordinator clusters, and they pick the nearest.
+/// Those endpoints are stable across sessions - unlike gameplay servers, which are allocated per match
+/// and never repeat - so they can be written into the profile as a <see cref="RegionEntry.Landmarks"/> list
+/// and used as a stand-in for the region itself. They sit in the region they represent and they answer
+/// ICMP, which is all this needs.
 ///
 /// Two things are measured with them, and the difference matters:
 ///
@@ -29,39 +31,39 @@ namespace GamePingBooster.Service.Tunnel;
 internal static class LandmarkProbe
 {
     /// <summary>How long a landmark may take to answer before it is treated as unreachable.</summary>
-    private const int TimeoutMs = 1500;
+    private const int TimeoutMs = 800;
 
     /// <summary>
-    /// Probes taken per landmark. Three, and the best is kept: ICMP is answered on the control
-    /// plane of whatever is at the far end and a single sample picks up its scheduling jitter,
-    /// while the minimum of three is a stable estimate of the path itself.
+    /// Probes taken per landmark. Best of two is kept to balance accuracy and speed.
     /// </summary>
-    private const int Attempts = 3;
+    private const int Attempts = 2;
 
     internal sealed record Result(string RegionId, string RegionName, IPAddress Landmark, double RttMs);
 
     /// <summary>
-    /// Measures every region that declares a landmark, over the physical path, best first.
+    /// Measures every region that declares a landmark, over the physical path in parallel, best first.
     /// Regions that declare none, or whose landmarks all stay silent, are not in the list.
     /// </summary>
     public static async Task<IReadOnlyList<Result>> RankRegionsAsync(
         IEnumerable<RegionEntry> regions, Action<string> log, CancellationToken ct)
     {
-        var results = new List<Result>();
-        foreach (var region in regions)
-        {
-            ct.ThrowIfCancellationRequested();
+        var list = regions.ToList();
+        if (list.Count == 0) return [];
 
+        var results = new ConcurrentBag<Result>();
+
+        await Parallel.ForEachAsync(list, new ParallelOptions
+        {
+            MaxDegreeOfParallelism = 16,
+            CancellationToken = ct
+        }, async (region, token) =>
+        {
             Result? best = null;
             foreach (var text in region.Landmarks)
             {
-                if (!IPAddress.TryParse(text, out var address))
-                {
-                    log($"  Ignoring landmark '{text}' in region '{region.Id}': not an IP address.");
-                    continue;
-                }
+                if (!IPAddress.TryParse(text, out var address)) continue;
 
-                var rtt = await MeasureAsync(address, ct).ConfigureAwait(false);
+                var rtt = await MeasureAsync(address, token).ConfigureAwait(false);
                 if (rtt is null) continue;
                 if (best is null || rtt < best.RttMs)
                 {
@@ -69,11 +71,21 @@ internal static class LandmarkProbe
                 }
             }
 
-            if (best is not null) results.Add(best);
+            if (best is not null)
+            {
+                results.Add(best);
+            }
+        }).ConfigureAwait(false);
+
+        var sorted = results.ToList();
+        sorted.Sort((a, b) => a.RttMs.CompareTo(b.RttMs));
+
+        foreach (var r in sorted)
+        {
+            log($"Landmark {r.RegionName} ({r.RegionId}) probed at {r.RttMs:F0} ms");
         }
 
-        results.Sort((a, b) => a.RttMs.CompareTo(b.RttMs));
-        return results;
+        return sorted;
     }
 
     /// <summary>Best of <see cref="Attempts"/> echoes over the physical path, or null if silent.</summary>

--- a/client/src/GamePingBooster.Service/Tunnel/TunnelEngine.cs
+++ b/client/src/GamePingBooster.Service/Tunnel/TunnelEngine.cs
@@ -1,12 +1,14 @@
-﻿using System.Buffers.Binary;
+using System.Buffers.Binary;
+using System.Diagnostics;
 using System.Net;
 using System.Net.Sockets;
+using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json;
 using GamePingBooster.Core.Ipc;
 using GamePingBooster.Core.Profiles;
 using GamePingBooster.Service.Native;
 using GamePingBooster.Service.Network;
-using System.Security.Cryptography;
 
 namespace GamePingBooster.Service.Tunnel;
 
@@ -72,6 +74,7 @@ internal sealed class TunnelEngine : IAsyncDisposable
     private volatile string _profileSource = "none";
 
     private GameEntry? _game;
+    private string? _selectedGameId;
     private RelayEntry? _relay;
     private volatile TunnelState _state = TunnelState.Disconnected;
     private volatile string _detail = "Not connected";
@@ -144,40 +147,38 @@ internal sealed class TunnelEngine : IAsyncDisposable
             var plaintext = _device.OpenSealedProfile(envelope);
             try
             {
-                json = System.Text.Encoding.UTF8.GetString(plaintext);
+                json = Encoding.UTF8.GetString(plaintext);
             }
             finally
             {
                 CryptographicOperations.ZeroMemory(plaintext);
             }
         }
-        catch (CryptographicException ex)
+        catch (Exception ex)
         {
-            return ex.Message;
+            return $"Could not open the profile bundle: {ex.Message}";
         }
 
-        ProfileBundle? parsed;
+        ProfileBundle parsed;
         try
         {
-            parsed = JsonSerializer.Deserialize(json, ProfileJsonContext.Default.ProfileBundle);
+            parsed = JsonSerializer.Deserialize(json, ProfileJsonContext.Default.ProfileBundle)
+                ?? throw new InvalidOperationException("Profile parsed as null.");
         }
         catch (JsonException ex)
         {
-            return $"The sealed profile did not contain a valid one: {ex.Message}";
+            return $"The decrypted profile is not valid JSON: {ex.Message}";
         }
-        if (parsed is null || parsed.Games.Count == 0) return "That profile names no games.";
 
-        try
+        if (parsed.SchemaVersion != 1)
         {
-            Directory.CreateDirectory(ServiceConfig.DefaultDirectory);
-            var tmp = SealedProfilePath + ".tmp";
-            await File.WriteAllBytesAsync(tmp, envelope, ct).ConfigureAwait(false);
-            File.Move(tmp, SealedProfilePath, overwrite: true);
+            return $"Unsupported profile schema version {parsed.SchemaVersion} (expected 1).";
         }
-        catch (Exception ex)
-        {
-            return $"Could not store the profile: {ex.Message}";
-        }
+
+        Directory.CreateDirectory(ServiceConfig.DefaultDirectory);
+        var tmp = SealedProfilePath + ".tmp";
+        File.WriteAllBytes(tmp, envelope);
+        File.Move(tmp, SealedProfilePath, overwrite: true);
 
         try
         {
@@ -188,7 +189,7 @@ internal sealed class TunnelEngine : IAsyncDisposable
             return $"Stored, but could not load it: {ex.Message}";
         }
 
-        var cidrs = parsed.Games.Sum(g => g.Regions.Sum(r => r.Cidrs.Count));
+        var cidrs = parsed.Games.Sum((GameEntry g) => g.Regions.Sum((RegionEntry r) => r.Cidrs.Count));
         _log($"Profile updated from the licence server: {parsed.Games.Count} game(s), " +
              $"{cidrs} ranges, {parsed.Relays.Count} relay(s). It applies from the next connect.");
         StatusChanged?.Invoke(Snapshot());
@@ -245,74 +246,254 @@ internal sealed class TunnelEngine : IAsyncDisposable
     ///                                been pushed yet, so a fresh install still connects.
     ///   self-hosted               -> the local file, exactly as before. Nothing pushes.
     /// </summary>
-    public async Task LoadProfileAsync(CancellationToken ct)
+    private List<string> ResolveProfileFiles()
     {
-        // "Licensed" is having a licence server, full stop. There is no separate profile
-        // address to configure: the endpoints all hang off the one URL somebody typed, and
-        // asking for a second address for the same server was needless.
-        var licensed = !string.IsNullOrWhiteSpace(_config.LicenceUrl);
-
-        // Where the installer puts it, and what the default in ServiceConfig resolves to.
-        var shipped = Path.Combine(AppContext.BaseDirectory, "profiles", "pubg-vn.json");
-
-        var local = Path.IsPathRooted(_config.ProfilePath)
-            ? _config.ProfilePath
-            : Path.Combine(AppContext.BaseDirectory, _config.ProfilePath);
-
-        // A configured path that no longer exists is not a dead end. It usually means an
-        // absolute path written by hand on a developer's machine, or an install that moved -
-        // and in both cases the profile the installer shipped is sitting right there.
-        if (!File.Exists(local) && File.Exists(shipped))
+        var candidates = new List<string>();
+        if (_config.ProfilePaths is { Count: > 0 })
         {
-            _log($"No profile at {local}; falling back to the one installed at {shipped}.");
-            local = shipped;
+            candidates.AddRange(_config.ProfilePaths);
+        }
+        if (!string.IsNullOrWhiteSpace(_config.ProfilePath))
+        {
+            candidates.Add(_config.ProfilePath);
+            var parentDir = Path.GetDirectoryName(_config.ProfilePath);
+            if (!string.IsNullOrWhiteSpace(parentDir))
+            {
+                candidates.Add(parentDir);
+            }
         }
 
-        var sealedExists = File.Exists(SealedProfilePath);
-        string source;
-        string json;
+        candidates.Add("profiles");
+        candidates.Add(Path.Combine(AppContext.BaseDirectory, "profiles"));
 
-        if ((licensed || !File.Exists(local)) && sealedExists)
+        var commonData = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
+        if (!string.IsNullOrWhiteSpace(commonData))
         {
-            // Opened in memory. The plaintext exists only for as long as it takes to parse.
+            candidates.Add(Path.Combine(commonData, "GamePingBooster", "profiles"));
+            candidates.Add(Path.Combine(commonData, "GamePingBooster", "profile.json"));
+        }
+
+        var progFiles = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+        if (!string.IsNullOrWhiteSpace(progFiles))
+        {
+            candidates.Add(Path.Combine(progFiles, "Game Ping Booster", "profiles"));
+        }
+
+        var files = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var rawPath in candidates)
+        {
+            if (string.IsNullOrWhiteSpace(rawPath)) continue;
+
+            string? path = null;
+            if (Path.IsPathRooted(rawPath))
+            {
+                if (File.Exists(rawPath) || Directory.Exists(rawPath)) path = rawPath;
+            }
+            else
+            {
+                var candidate1 = Path.Combine(AppContext.BaseDirectory, rawPath);
+                if (File.Exists(candidate1) || Directory.Exists(candidate1))
+                {
+                    path = candidate1;
+                }
+                else
+                {
+                    var candidate2 = Path.Combine(Directory.GetCurrentDirectory(), rawPath);
+                    if (File.Exists(candidate2) || Directory.Exists(candidate2))
+                    {
+                        path = candidate2;
+                    }
+                    else
+                    {
+                        var candidate3 = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", rawPath));
+                        if (File.Exists(candidate3) || Directory.Exists(candidate3))
+                        {
+                            path = candidate3;
+                        }
+                    }
+                }
+            }
+
+            if (path is null) continue;
+
+            if (File.Exists(path))
+            {
+                files.Add(Path.GetFullPath(path));
+            }
+            else if (Directory.Exists(path))
+            {
+                try
+                {
+                    var dirFiles = Directory.GetFiles(path, "*.json", SearchOption.TopDirectoryOnly);
+                    var realFiles = new HashSet<string>(
+                        dirFiles.Where(f => !f.EndsWith(".example.json", StringComparison.OrdinalIgnoreCase))
+                                .Select(f => Path.GetFileNameWithoutExtension(f)),
+                        StringComparer.OrdinalIgnoreCase);
+
+                    foreach (var f in dirFiles)
+                    {
+                        var fileName = Path.GetFileName(f);
+                        if (fileName.EndsWith(".example.json", StringComparison.OrdinalIgnoreCase))
+                        {
+                            var baseName = fileName[..^".example.json".Length];
+                            if (realFiles.Contains(baseName))
+                            {
+                                continue;
+                            }
+                        }
+                        files.Add(Path.GetFullPath(f));
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _log($"Warning: could not scan profile directory {path}: {ex.Message}");
+                }
+            }
+        }
+
+        return [.. files];
+    }
+
+    public async Task LoadProfileAsync(CancellationToken ct)
+    {
+        var licensed = !string.IsNullOrWhiteSpace(_config.LicenceUrl);
+        var sealedExists = File.Exists(SealedProfilePath);
+        var profileFiles = ResolveProfileFiles();
+
+        string source;
+        ProfileBundle? profile = null;
+        var sourceDescription = "";
+
+        if ((licensed || profileFiles.Count == 0) && sealedExists)
+        {
             var envelope = await File.ReadAllBytesAsync(SealedProfilePath, ct).ConfigureAwait(false);
             var plaintext = _device.OpenSealedProfile(envelope);
             try
             {
-                json = System.Text.Encoding.UTF8.GetString(plaintext);
+                var json = Encoding.UTF8.GetString(plaintext);
+                profile = JsonSerializer.Deserialize(json, ProfileJsonContext.Default.ProfileBundle);
             }
             finally
             {
                 CryptographicOperations.ZeroMemory(plaintext);
             }
             source = licensed ? "pushed" : "cached";
+            sourceDescription = SealedProfilePath;
         }
-        else if (File.Exists(local))
+        else if (profileFiles.Count > 0)
         {
-            json = await File.ReadAllTextAsync(local, ct).ConfigureAwait(false);
-            source = "shipped";
+            ProfileBundle? combined = null;
+            var loadedFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var file in profileFiles)
+            {
+                try
+                {
+                    var json = await File.ReadAllTextAsync(file, ct).ConfigureAwait(false);
+                    var bundle = JsonSerializer.Deserialize(json, ProfileJsonContext.Default.ProfileBundle);
+                    if (bundle is null || bundle.Games.Count == 0) continue;
+
+                    if (combined is null)
+                    {
+                        combined = bundle;
+                    }
+                    else
+                    {
+                        foreach (var g in bundle.Games)
+                        {
+                            var existingGame = combined.Games.FirstOrDefault(x => string.Equals(x.Id, g.Id, StringComparison.OrdinalIgnoreCase));
+                            if (existingGame is null)
+                            {
+                                combined.Games.Add(g);
+                            }
+                            else
+                            {
+                                foreach (var reg in g.Regions)
+                                {
+                                    if (!existingGame.Regions.Any(r => string.Equals(r.Id, reg.Id, StringComparison.OrdinalIgnoreCase)))
+                                    {
+                                        existingGame.Regions.Add(reg);
+                                    }
+                                }
+                                foreach (var proc in g.ProcessNames)
+                                {
+                                    if (!existingGame.ProcessNames.Contains(proc, StringComparer.OrdinalIgnoreCase))
+                                    {
+                                        existingGame.ProcessNames.Add(proc);
+                                    }
+                                }
+                                foreach (var addr in g.LobbyAddresses)
+                                {
+                                    if (!existingGame.LobbyAddresses.Contains(addr, StringComparer.OrdinalIgnoreCase))
+                                    {
+                                        existingGame.LobbyAddresses.Add(addr);
+                                    }
+                                }
+                            }
+                        }
+
+                        foreach (var r in bundle.Relays)
+                        {
+                            var existing = combined.Relays.FirstOrDefault(x => string.Equals(x.Endpoint, r.Endpoint, StringComparison.OrdinalIgnoreCase));
+                            if (existing is null)
+                            {
+                                if (!combined.Relays.Any(x => string.Equals(x.Id, r.Id, StringComparison.OrdinalIgnoreCase)))
+                                {
+                                    combined.Relays.Add(r);
+                                }
+                            }
+                            else if (existing.Id.StartsWith("relay-", StringComparison.OrdinalIgnoreCase) && !r.Id.StartsWith("relay-", StringComparison.OrdinalIgnoreCase))
+                            {
+                                // A named profile relay (e.g. "sg") takes precedence over a generic placeholder ("relay-1").
+                                existing.Id = r.Id;
+                                existing.Name = r.Name;
+                                existing.Location = r.Location;
+                            }
+                        }
+
+                        if (bundle.GeneratedUtc > combined.GeneratedUtc)
+                        {
+                            combined.GeneratedUtc = bundle.GeneratedUtc;
+                        }
+                    }
+                    loadedFiles.Add(Path.GetFileName(file));
+                }
+                catch (Exception ex)
+                {
+                    _log($"Warning: could not read profile file {file}: {ex.Message}");
+                }
+            }
+
+            if (combined is not null && combined.Games.Count > 0)
+            {
+                profile = combined;
+                source = "shipped";
+                sourceDescription = string.Join(", ", loadedFiles);
+            }
+            else
+            {
+                throw new FileNotFoundException(
+                    $"No valid profiles found at {_config.ProfilePath} or in profiles directory, and nothing from the licence server either.");
+            }
         }
         else
         {
             throw new FileNotFoundException(
-                $"No profile at {_config.ProfilePath} and nothing from the licence server either.");
+                $"No profiles found at {_config.ProfilePath} and nothing from the licence server either.");
         }
 
-        _profile = JsonSerializer.Deserialize(json, ProfileJsonContext.Default.ProfileBundle)
-                   ?? throw new InvalidOperationException("The profile is not valid.");
+        _profile = profile ?? throw new InvalidOperationException("The profile is not valid.");
         _profileSource = source;
-        var chosen = source == "shipped" ? local : SealedProfilePath;
 
         if (licensed && source != "pushed")
         {
-            // Loud, because it is the silent failure this whole path exists to avoid: the tunnel
-            // will work perfectly on ranges that may be months old.
-            _log($"Loaded the {source} profile from {chosen}. A licence server is configured but " +
-                 "nothing has been pushed yet - sign in so the app can fetch the current one.");
+            _log($"Loaded {source} profile from {sourceDescription} ({_profile.Games.Count} game(s): {string.Join(", ", _profile.Games.Select(g => g.Name))}). " +
+                 "A licence server is configured but nothing has been pushed yet - sign in so the app can fetch the current one.");
         }
         else
         {
-            _log($"Loaded the {source} profile from {chosen}");
+            _log($"Loaded {source} profile from {sourceDescription} ({_profile.Games.Count} game(s): {string.Join(", ", _profile.Games.Select(g => g.Name))}, {_profile.Relays.Count} relay(s))");
         }
         ApplySelfHostedRelay();
     }
@@ -355,8 +536,19 @@ internal sealed class TunnelEngine : IAsyncDisposable
                 _log($"Could not reload the profile ({ex.Message}) - continuing with the one already loaded.");
             }
 
-            _game = FindGame(gameId ?? _config.DefaultGameId);
-            var psk = System.Text.Encoding.UTF8.GetBytes(_config.Psk);
+            // Explicit game selection is required before bringing the tunnel up. Without one,
+            // the engine has no way of knowing which CIDR ranges to install.
+            _selectedGameId = string.IsNullOrWhiteSpace(gameId) ? _selectedGameId : gameId;
+            if (string.IsNullOrWhiteSpace(_selectedGameId))
+            {
+                throw new InvalidOperationException("No game selected. Please select a game before connecting.");
+            }
+
+            _game = FindGame(_selectedGameId);
+
+            var runningProc = FindRunningGameProcess();
+
+            var psk = Encoding.UTF8.GetBytes(_config.Psk);
 
             // Choose the relay before creating anything. Probing is pure UDP - no adapter, no
             // routes - so a relay that turns out to be unreachable costs nothing but a timeout.
@@ -376,7 +568,7 @@ internal sealed class TunnelEngine : IAsyncDisposable
             _routes = new RouteManager();
             _routes.PinRelayRoute(endpoint.Address);
 
-            _routes.ConfigureAdapter(_adapter.InterfaceIndex, session.ClientIp, prefixLength: 24, session.Mtu);
+            RouteManager.ConfigureAdapter(_adapter.InterfaceIndex, session.ClientIp, prefixLength: 24, session.Mtu);
             _tunnel.StartPumping(_adapter, token);
 
             // The lobby goes on the tunnel NOW, before the game exists, rather than with the game
@@ -386,23 +578,25 @@ internal sealed class TunnelEngine : IAsyncDisposable
             InstallLobbyRoutes();
 
             // Watch the game so routes come and go with it.
-            _watcher = new GameProcessWatcher(_game.ProcessNames);
+            _watcher = new GameProcessWatcher(GetAllProcessNames());
             _watcher.GameStateChanged += OnGameStateChanged;
             _watcher.Start();
-
-            if (_config.RouteWithoutGame)
-            {
-                _log("routeWithoutGame = true - installing routes now without waiting for the game (debug mode).");
-                InstallRoutes();
-            }
 
             StartSupervisor(token);
             StartGamePingProbe(token);
 
-            SetState(TunnelState.Connected,
-                _watcher.IsGameRunning
-                    ? $"Connected to {_relay.Name} - accelerating {_game.Name}"
-                    : $"Connected to {_relay.Name} - waiting for {_game.Name} to start");
+            if (runningProc is not null || _config.RouteWithoutGame)
+            {
+                _log($"Game process {runningProc ?? "forced"}.exe is already running - installing routes for {_game.Name}.");
+                InstallLobbyRoutes();
+                InstallRoutes();
+                SetState(TunnelState.Connected, $"Optimizing {_game.Name} through {_relay.Name}");
+            }
+            else
+            {
+                _log($"Connected to {_relay.Name}. Waiting for game to launch... Please open {_game.Name}.");
+                SetState(TunnelState.Connected, $"Waiting for game to launch... Please open {_game.Name}.");
+            }
         }
         catch (Exception ex)
         {
@@ -576,7 +770,11 @@ internal sealed class TunnelEngine : IAsyncDisposable
             {
                 var client = new TunnelClient(ParseEndpoint(pinned.Endpoint), AuthFor(pinned, psk), _clientId, _log);
                 await client.HandshakeAsync(attempts: 4, ct).ConfigureAwait(false);
-                await ReportBothLegsAsync(pinned, client, ct).ConfigureAwait(false);
+                _ = Task.Run(async () =>
+                {
+                    try { await ReportBothLegsAsync(pinned, client, CancellationToken.None).ConfigureAwait(false); }
+                    catch { }
+                }, CancellationToken.None);
                 return (pinned, client);
             }
             _log($"The profile has no relay '{preferredId}' - measuring all of them instead.");
@@ -587,7 +785,11 @@ internal sealed class TunnelEngine : IAsyncDisposable
             var only = candidates[0];
             var client = new TunnelClient(ParseEndpoint(only.Endpoint), AuthFor(only, psk), _clientId, _log);
             await client.HandshakeAsync(attempts: 4, ct).ConfigureAwait(false);
-            await ReportBothLegsAsync(only, client, ct).ConfigureAwait(false);
+            _ = Task.Run(async () =>
+            {
+                try { await ReportBothLegsAsync(only, client, CancellationToken.None).ConfigureAwait(false); }
+                catch { }
+            }, CancellationToken.None);
             return (only, client);
         }
 
@@ -1161,7 +1363,7 @@ internal sealed class TunnelEngine : IAsyncDisposable
         if (previous is null || adapter is null || routes is null) return;
 
         var previousIp = _tunnel?.Session.ClientIp;
-        var psk = System.Text.Encoding.UTF8.GetBytes(_config.Psk);
+        var psk = Encoding.UTF8.GetBytes(_config.Psk);
 
         // Flush before the relay changes underneath it: a destinations line naming the wrong
         // relay is worse than no line, because the whole point is comparing one against another.
@@ -1262,7 +1464,7 @@ internal sealed class TunnelEngine : IAsyncDisposable
                     else
                     {
                         _log($"Got a different inner IP ({session.ClientIp}) - reconfiguring the adapter.");
-                        routes.ConfigureAdapter(adapter.InterfaceIndex, session.ClientIp, prefixLength: 24, session.Mtu);
+                        RouteManager.ConfigureAdapter(adapter.InterfaceIndex, session.ClientIp, prefixLength: 24, session.Mtu);
                     }
 
                     InstallLobbyRoutes();
@@ -1348,18 +1550,24 @@ internal sealed class TunnelEngine : IAsyncDisposable
                     return;
                 }
 
-                _log($"Detected {processName}.exe running - installing routes.");
+                if (_game is null && !string.IsNullOrEmpty(_selectedGameId))
+                {
+                    _game = FindGame(_selectedGameId);
+                }
+
+                _log($"Detected {processName}.exe running - installing routes for {_game?.Name}.");
+                InstallLobbyRoutes();
                 InstallRoutes();
-                SetState(TunnelState.Connected, $"Accelerating {_game?.Name} through {_relay?.Name}");
+                SetState(TunnelState.Connected, $"Optimizing {_game?.Name} through {_relay?.Name}");
             }
             else
             {
                 _log("The game exited - removing routes, other traffic returns to the normal path.");
                 if (_adapter is not null) _routes?.RemoveGameRoutes(_adapter.InterfaceIndex);
-                // Do not claim Connected while a reconnect is still in progress.
                 if (_tunnel is not null)
                 {
-                    SetState(TunnelState.Connected, $"Connected to {_relay?.Name} - waiting for {_game?.Name} to start");
+                    var waitingTarget = _game?.Name ?? "the game";
+                    SetState(TunnelState.Connected, $"Waiting for game to launch... Please open {waitingTarget}.");
                 }
             }
         }
@@ -1368,6 +1576,111 @@ internal sealed class TunnelEngine : IAsyncDisposable
             _error = ex.Message;
             SetState(TunnelState.Faulted, "Failed to update the routing table");
             _log($"Error while adding or removing routes: {ex}");
+        }
+    }
+
+    private string? FindRunningGameProcess()
+    {
+        var names = GetAllProcessNames()
+            .Select(n => n.EndsWith(".exe", StringComparison.OrdinalIgnoreCase) ? n[..^4] : n)
+            .Where(n => n.Length > 0)
+            .Distinct(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var name in names)
+        {
+            try
+            {
+                var procs = Process.GetProcessesByName(name);
+                try
+                {
+                    if (procs.Length > 0) return name;
+                }
+                finally
+                {
+                    foreach (var p in procs) p.Dispose();
+                }
+            }
+            catch
+            {
+                // Ignore transient process enumeration errors
+            }
+        }
+        return null;
+    }
+
+    private List<string> GetAllProcessNames()
+    {
+        if (_profile is null || _profile.Games.Count == 0) return [];
+        if (!string.IsNullOrEmpty(_selectedGameId))
+        {
+            var specific = _profile.Games.FirstOrDefault(g => g.Id.Equals(_selectedGameId, StringComparison.OrdinalIgnoreCase));
+            if (specific is not null) return specific.ProcessNames;
+        }
+        return _game is not null ? _game.ProcessNames : [];
+    }
+
+    private GameEntry? FindGameForProcess(string? processName)
+    {
+        if (_profile is null || string.IsNullOrWhiteSpace(processName)) return _game;
+
+        if (!string.IsNullOrEmpty(_selectedGameId))
+        {
+            return _profile.Games.FirstOrDefault(g => g.Id.Equals(_selectedGameId, StringComparison.OrdinalIgnoreCase)) ?? _game;
+        }
+
+        var procNorm = processName.EndsWith(".exe", StringComparison.OrdinalIgnoreCase) ? processName[..^4] : processName;
+        return _profile.Games.FirstOrDefault(g => g.ProcessNames.Any(p =>
+        {
+            var pNorm = p.EndsWith(".exe", StringComparison.OrdinalIgnoreCase) ? p[..^4] : p;
+            return string.Equals(pNorm, procNorm, StringComparison.OrdinalIgnoreCase);
+        })) ?? _game ?? _profile.Games.FirstOrDefault();
+    }
+
+    public void SetSelectedGame(string? gameId)
+    {
+        if (string.IsNullOrWhiteSpace(gameId))
+        {
+            return;
+        }
+
+        _selectedGameId = gameId;
+        _log($"Selected game changed to: {_selectedGameId}");
+
+        if (_profile is not null)
+        {
+            var specific = _profile.Games.FirstOrDefault(g => g.Id.Equals(_selectedGameId, StringComparison.OrdinalIgnoreCase));
+            if (specific is not null)
+            {
+                _game = specific;
+            }
+
+            if (_watcher is not null)
+            {
+                _watcher.GameStateChanged -= OnGameStateChanged;
+                _watcher.Dispose();
+                _watcher = new GameProcessWatcher(GetAllProcessNames());
+                _watcher.GameStateChanged += OnGameStateChanged;
+                _watcher.Start();
+
+                var runningProc = FindRunningGameProcess();
+                if (runningProc is null && _adapter is not null)
+                {
+                    _routes?.RemoveGameRoutes(_adapter.InterfaceIndex);
+                    if (_tunnel is not null)
+                    {
+                        var waitingTarget = _game?.Name ?? "the game";
+                        SetState(TunnelState.Connected, $"Waiting for game to launch... Please open {waitingTarget}.");
+                    }
+                }
+                else if (runningProc is not null)
+                {
+                    OnGameStateChanged(true, runningProc);
+                }
+            }
+            else
+            {
+                StatusChanged?.Invoke(Snapshot());
+            }
         }
     }
 
@@ -1566,6 +1879,9 @@ internal sealed class TunnelEngine : IAsyncDisposable
         // reading the property twice inside the initializer could catch the probe going stale
         // between the two - a status that says "measured" over an estimated number.
         var direct = DirectGamePingMs;
+        var runningProc = FindRunningGameProcess();
+        var isRunning = _watcher?.IsGameRunning ?? (runningProc is not null);
+        var currentGameName = _game?.Name ?? (runningProc is not null ? FindGameForProcess(runningProc)?.Name : null);
 
         return new StatusMessage
         {
@@ -1602,8 +1918,10 @@ internal sealed class TunnelEngine : IAsyncDisposable
             GamePingDirect = direct is not null,
             GameRegionName = _path?.RegionName,
             LossRatio = _tunnel?.LossRatio,
-            GameRunning = _watcher?.IsGameRunning ?? false,
+            GameRunning = isRunning,
             GameName = _game?.Name,
+            AvailableGames = _profile?.Games.Select(g => new GameInfoItem { Id = g.Id, Name = g.Name }).ToList() ?? [],
+            SelectedGameId = _selectedGameId,
             ActiveRoutes = _routes?.ActiveRouteCount ?? 0,
             PacketsSent = _tunnel?.PacketsSent ?? 0,
             PacketsReceived = _tunnel?.PacketsReceived ?? 0,
@@ -1630,7 +1948,7 @@ internal sealed class TunnelEngine : IAsyncDisposable
             // which the UI reads as "never" - correct on a machine that has never signed in.
             ProfileUpdatedAt = File.Exists(SealedProfilePath)
                 ? new DateTimeOffset(File.GetLastWriteTimeUtc(SealedProfilePath)).ToUnixTimeSeconds()
-                : null,
+                : (_profile?.GeneratedUtc != default ? _profile?.GeneratedUtc.ToUnixTimeSeconds() : null),
         };
     }
 
@@ -1760,7 +2078,7 @@ internal sealed class TunnelEngine : IAsyncDisposable
         var previousRelayId = _config.DefaultRelayId;
 
         _config.RelayEndpoints = cleaned;
-        _config.Psk = psk;
+        _config.Psk = psk ?? "";
         if (licenceUrl is not null) _config.LicenceUrl = licenceUrl;
 
         // Clear the preferred relay id along with it.
@@ -1810,9 +2128,21 @@ internal sealed class TunnelEngine : IAsyncDisposable
         StatusChanged?.Invoke(Snapshot());
     }
 
-    private GameEntry FindGame(string id) =>
-        _profile!.Games.FirstOrDefault(g => g.Id.Equals(id, StringComparison.OrdinalIgnoreCase))
-        ?? throw new InvalidOperationException($"The profile has no game with id '{id}'.");
+    private GameEntry FindGame(string? id)
+    {
+        if (_profile is null || _profile.Games.Count == 0)
+            throw new InvalidOperationException("The profile declares no games.");
+
+        if (string.IsNullOrWhiteSpace(id))
+        {
+            throw new InvalidOperationException("No game selected. Please select a game before connecting.");
+        }
+
+        var found = _profile.Games.FirstOrDefault(g => g.Id.Equals(id, StringComparison.OrdinalIgnoreCase));
+        if (found is not null) return found;
+
+        throw new InvalidOperationException($"Game '{id}' not found in profile.");
+    }
 
     private RelayEntry FindRelay(string? id)
     {

--- a/gpb.ps1
+++ b/gpb.ps1
@@ -686,7 +686,8 @@ switch ($Verb.ToLowerInvariant()) {
         # commercial use. See installer/GamePingBooster.iss.
         $iscc = @(
             "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe",
-            "$env:ProgramFiles\Inno Setup 6\ISCC.exe"
+            "$env:ProgramFiles\Inno Setup 6\ISCC.exe",
+            "$env:LocalAppData\Programs\Inno Setup 6\ISCC.exe"
         ) | Where-Object { Test-Path $_ } | Select-Object -First 1
 
         if (-not $iscc) {
@@ -723,12 +724,16 @@ switch ($Verb.ToLowerInvariant()) {
             # and an installer that shipped without it produced an app that crashed on launch
             # with a TypeInitializationException naming neither the file nor the installer.
             'libSkiaSharp' = Join-Path $client 'src\GamePingBooster.App\bin\Release\net9.0-windows\win-x64\publish\libSkiaSharp.dll'
-            'the profile'  = Join-Path $root 'profiles\pubg-vn.json'
         }
         foreach ($what in $required.Keys) {
             if (-not (Test-Path $required[$what])) {
                 throw "Cannot package: $what is missing at $($required[$what])"
             }
+        }
+
+        $prodProfiles = @(Get-ChildItem (Join-Path $root 'profiles') -Filter "*.json" | Where-Object { $_.Name -notlike "*.example.json" })
+        if ($prodProfiles.Count -eq 0) {
+            throw "Cannot package: no production profiles found in profiles/ (excluding *.example.json)"
         }
 
         Say "Building the installer"

--- a/installer/GamePingBooster.iss
+++ b/installer/GamePingBooster.iss
@@ -102,10 +102,9 @@ Source: "{#AppPublish}\*";     DestDir: "{app}"; Excludes: "*.pdb,*.zip"; Flags:
 ; downloaded into the tree by hand.
 Source: "{#Root}\client\native\wintun\wintun.dll"; DestDir: "{app}"; Flags: ignoreversion
 
-; The profile is content: the game's address ranges. It is read relative to the install
-; directory, which is why ServiceConfig's profilePath default is a relative path and why nothing
-; here writes an absolute one - an absolute path only works on the machine it was written on.
-Source: "{#Root}\profiles\pubg-vn.json"; DestDir: "{app}\profiles"; Flags: ignoreversion
+; The profiles are content: the game address ranges. It is read relative to the install
+; directory. Automatically include all production profiles, excluding example/template files.
+Source: "{#Root}\profiles\*.json"; DestDir: "{app}\profiles"; Excludes: "*.example.json"; Flags: ignoreversion
 
 [Dirs]
 ; The service writes its configuration and logs here, as LocalSystem. Nothing is placed in it at

--- a/profiles/cs2-vn.example.json
+++ b/profiles/cs2-vn.example.json
@@ -1,0 +1,61 @@
+﻿{
+  "schemaVersion":  1,
+  "generatedUtc":  "2026-09-12T12:13:47Z",
+  "note":  "CS2 COMPLETE server IPs - all 4 Valve SDR POPs from Steam API (https://api.steampowered.com/ISteamApps/GetSDRConfig/v1/?appid=730). Generated 2026-09-12.",
+  "games":  [
+    {
+      "id":  "cs2",
+      "name":  "Counter-Strike 2",
+      "processNames":  [
+        "cs2.exe"
+      ],
+      "lobbyAddresses":  [],
+      "regions":  [
+        {
+          "id":  "cs2-sgp",
+          "name":  "Singapore",
+          "source":  "steam-sdr:sgp",
+          "note":  "Valve SDR SGP relay cluster.",
+          "cidrs":  [
+            "103.10.124.0/24"
+          ]
+        },
+        {
+          "id":  "cs2-hkg",
+          "name":  "Hong Kong",
+          "source":  "steam-sdr:hkg",
+          "note":  "Valve SDR HKG relay cluster.",
+          "cidrs":  [
+            "103.28.54.0/24"
+          ]
+        },
+        {
+          "id":  "cs2-tyo",
+          "name":  "Tokyo Koto City (Japan)",
+          "source":  "steam-sdr:tyo",
+          "note":  "Valve SDR TYO relay cluster.",
+          "cidrs":  [
+            "45.121.184.0/24"
+          ]
+        },
+        {
+          "id":  "cs2-seo",
+          "name":  "Seoul (South Korea)",
+          "source":  "steam-sdr:seo",
+          "note":  "Valve SDR SEO relay cluster.",
+          "cidrs":  [
+            "146.66.152.0/24"
+          ]
+        }
+      ]
+    }
+  ],
+  "relays":  [
+    {
+      "id":  "relay-1",
+      "name":  "Your relay",
+      "location":  "Singapore",
+      "endpoint":  "203.0.113.10:51820"
+    }
+  ]
+}

--- a/tools/Update-InstalledService.ps1
+++ b/tools/Update-InstalledService.ps1
@@ -1,0 +1,138 @@
+$ErrorActionPreference = 'Stop'
+
+Write-Host "========================================================" -ForegroundColor Cyan
+Write-Host "Updating Game Ping Booster Service & Profiles" -ForegroundColor Cyan
+Write-Host "========================================================" -ForegroundColor Cyan
+
+$svcName = 'GamePingBooster'
+Write-Host "1. Stopping $svcName service..." -ForegroundColor Yellow
+try {
+    Stop-Service $svcName -Force -ErrorAction SilentlyContinue
+} catch {}
+Start-Sleep -Seconds 2
+
+# Ensure any existing process is stopped
+$procs = Get-Process gpb-service, GamePingBooster -ErrorAction SilentlyContinue
+if ($procs) {
+    Write-Host "Terminating active processes..." -ForegroundColor Yellow
+    $procs | Stop-Process -Force -ErrorAction SilentlyContinue
+    Start-Sleep -Seconds 1
+}
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$svcPublish = Join-Path $repoRoot "client\src\GamePingBooster.Service\bin\Release\net9.0-windows\win-x64\publish"
+$appPublish = Join-Path $repoRoot "client\src\GamePingBooster.App\bin\Release\net9.0-windows\win-x64\publish"
+$profilesDir = Join-Path $repoRoot "profiles"
+
+$progFiles = 'C:\Program Files\Game Ping Booster'
+$progData  = 'C:\ProgramData\GamePingBooster'
+
+# 2. Update Program Files
+if (Test-Path $progFiles) {
+    Write-Host "2. Copying binaries to '$progFiles'..." -ForegroundColor Cyan
+    Copy-Item "$svcPublish\gpb-service.exe" "$progFiles\gpb-service.exe" -Force
+    Copy-Item "$appPublish\GamePingBooster.exe" "$progFiles\GamePingBooster.exe" -Force
+    if (Test-Path "$svcPublish\wintun.dll") {
+        Copy-Item "$svcPublish\wintun.dll" "$progFiles\wintun.dll" -Force
+    }
+    Copy-Item "$appPublish\*.dll" "$progFiles\" -Force
+
+    $destProfiles = Join-Path $progFiles "profiles"
+    if (-not (Test-Path $destProfiles)) {
+        New-Item -ItemType Directory -Path $destProfiles -Force | Out-Null
+    }
+    Copy-Item "$profilesDir\*.json" $destProfiles -Force
+    Write-Host "   Program Files updated successfully." -ForegroundColor Green
+}
+
+# 3. Update ProgramData
+if (-not (Test-Path $progData)) {
+    New-Item -ItemType Directory -Path $progData -Force | Out-Null
+}
+
+Write-Host "3. Updating configuration in '$progData'..." -ForegroundColor Cyan
+$cfgFile = Join-Path $progData "config.json"
+$existingPsk = ""
+$existingRelays = @()
+
+# 1. Read existing config from ProgramData
+if (Test-Path $cfgFile) {
+    try {
+        $raw = Get-Content $cfgFile -Raw | ConvertFrom-Json
+        if ($raw.psk) { $existingPsk = $raw.psk }
+        if ($raw.relayEndpoints -and $raw.relayEndpoints.Count -gt 0) {
+            $existingRelays = @($raw.relayEndpoints)
+        }
+    } catch {}
+}
+
+# 2. Check local client/config.json if needed
+$localClientCfg = Join-Path $repoRoot "client\config.json"
+if ((-not $existingPsk -or $existingRelays.Count -eq 0) -and (Test-Path $localClientCfg)) {
+    try {
+        $raw = Get-Content $localClientCfg -Raw | ConvertFrom-Json
+        if (-not $existingPsk -and $raw.psk) { $existingPsk = $raw.psk }
+        if ($existingRelays.Count -eq 0 -and $raw.relayEndpoints) {
+            $existingRelays = @($raw.relayEndpoints)
+        }
+    } catch {}
+}
+
+# 3. Check .env if present
+$envFile = Join-Path $repoRoot ".env"
+if (Test-Path $envFile) {
+    Get-Content $envFile | ForEach-Object {
+        $line = $_.Trim()
+        if ($line -match '^GPB_PSK=(.*)$') {
+            if (-not $existingPsk) { $existingPsk = $Matches[1].Trim('"', "'", ' ') }
+        }
+        if ($line -match '^GPB_RELAY_ENDPOINT=(.*)$') {
+            if ($existingRelays.Count -eq 0) { $existingRelays = @($Matches[1].Trim('"', "'", ' ')) }
+        }
+    }
+}
+
+# 4. Check gpb.conf if relay is still empty
+$gpbConfFile = Join-Path $repoRoot "gpb.conf"
+if ($existingRelays.Count -eq 0 -and (Test-Path $gpbConfFile)) {
+    . (Join-Path $repoRoot 'tools\GpbConf.ps1')
+    $conf = Read-GpbConf $gpbConfFile
+    $default = $conf['RELAY_DEFAULT']
+    if ($default) {
+        $r = Get-GpbRelay -Name $default -RepoRoot $repoRoot
+        if ($r -and $r.Endpoint) {
+            $existingRelays = @($r.Endpoint)
+        }
+    }
+}
+
+$newConfig = [ordered]@{
+    profileUrl     = $null
+    profilePath    = "profiles"
+    psk            = $existingPsk
+    licenceUrl     = ""
+    defaultRelayId = $null
+    relayEndpoints = $existingRelays
+    defaultGameId  = $null
+    adapterName    = "Game Ping Booster"
+    routeWithoutGame = $false
+}
+$newConfig | ConvertTo-Json -Depth 5 | Set-Content $cfgFile -Encoding utf8
+
+$dataProfiles = Join-Path $progData "profiles"
+if (-not (Test-Path $dataProfiles)) {
+    New-Item -ItemType Directory -Path $dataProfiles -Force | Out-Null
+}
+Copy-Item "$profilesDir\*.json" $dataProfiles -Force
+
+# 4. Start service
+Write-Host "4. Starting $svcName service..." -ForegroundColor Green
+Start-Service $svcName
+Start-Sleep -Seconds 2
+
+$status = Get-Service $svcName
+Write-Host "========================================================" -ForegroundColor Green
+Write-Host "Service '$svcName' is now: $($status.Status)" -ForegroundColor Green
+Write-Host "Multi-game support (CS2, PUBG) active!" -ForegroundColor Green
+Write-Host "========================================================" -ForegroundColor Green
+Start-Sleep -Seconds 2

--- a/tools/profile-builder/Build-Cs2Profile.ps1
+++ b/tools/profile-builder/Build-Cs2Profile.ps1
@@ -1,0 +1,221 @@
+<#
+.SYNOPSIS
+    Generate Counter-Strike 2 (CS2) routing profile from official Valve Steam SDR Web API.
+
+.DESCRIPTION
+    CS2 does not use traditional game servers hosted directly on AWS/Azure; all game
+    matchmaking and game traffic is routed through Valve Corporation's Steam Datagram
+    Relay (SDR) network.
+
+    This script queries the official Valve Steam SDR configuration endpoint:
+      https://api.steampowered.com/ISteamApps/GetSDRConfig/v1/?appid=730
+
+    For each active Point of Presence (POP):
+      1. Extracts all relay server IPv4 addresses.
+      2. Groups them into dedicated /24 subnets owned by Valve (AS32590).
+      3. Orders regions priority-first for Vietnamese / Southeast Asian players:
+         SGP (Singapore), HKG (Hong Kong), TYO (Tokyo), SEO (Seoul), followed by
+         Oceania, India, Middle East, Europe, Americas, and Africa.
+      4. Formats into a GamePingBooster profile bundle and validates with Test-Profile.ps1.
+
+.PARAMETER ProfilePath
+    Target output profile path. Defaults to ..\..\profiles\cs2-vn.example.json.
+
+.PARAMETER RelayEndpoint
+    The relay endpoint IP:port to populate in the profile. Defaults to RFC 5737 documentation
+    address (203.0.113.10:51820).
+
+.PARAMETER DryRun
+    Fetch, parse, and display the discovered regions without writing to disk.
+
+.EXAMPLE
+    .\Build-Cs2Profile.ps1
+
+.EXAMPLE
+    .\Build-Cs2Profile.ps1 -ProfilePath ..\..\profiles\cs2-vn.json -RelayEndpoint "203.0.113.10:51820"
+#>
+
+[CmdletBinding()]
+param(
+    [string]$ProfilePath,
+    [string]$RelayEndpoint = "203.0.113.10:51820",
+    [switch]$All,
+    [switch]$DryRun
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not $ProfilePath) {
+    $ProfilePath = Join-Path $PSScriptRoot '..\..\profiles\cs2-vn.example.json'
+}
+
+# Re-indent to two spaces per level matching the rest of the repository.
+function Format-Json {
+    param([string]$Json)
+    try {
+        $lines = $Json -split "`r?`n" | ForEach-Object { $_.Trim() } | Where-Object { $_ -ne '' }
+        $sb = New-Object System.Text.StringBuilder
+        $depth = 0
+        foreach ($line in $lines) {
+            if ($line -match '^[\}\]]') { $depth-- }
+            $null = $sb.AppendLine(('  ' * [Math]::Max($depth, 0)) + $line)
+            if ($line -match '[\{\[]$') { $depth++ }
+        }
+        $out = $sb.ToString() -replace '\[\s*\r?\n\s*\]', '[]'
+        $null = ConvertFrom-Json -InputObject $out
+        return $out
+    } catch {
+        return $Json
+    }
+}
+
+Write-Host "Fetching latest CS2 Steam SDR configuration from Valve API..." -ForegroundColor Cyan
+$apiUrl = "https://api.steampowered.com/ISteamApps/GetSDRConfig/v1/?appid=730"
+$sdrConfig = Invoke-RestMethod -Uri $apiUrl -TimeoutSec 15
+
+if (-not $sdrConfig.pops) {
+    throw "Failed to retrieve POPs from Steam SDR API."
+}
+
+# Priority ordering for Southeast Asian / Vietnamese players
+$priorityPops = @(
+    'sgp', # Singapore (Primary)
+    'hkg', # Hong Kong
+    'tyo', 'tyo1', 'tyo2', # Tokyo
+    'seo', # Seoul
+    'can', 'canm', 'cant', 'canu', # China Guangzhou
+    'sha', 'sham', 'shat', 'shau', # China Shanghai
+    'tsn', 'tsnm', 'tsnt', 'tsnu', # China Tianjin
+    'wuh', # China Wuhan
+    'bom', 'bom2', # Mumbai
+    'del', 'del2', # Delhi
+    'maa', 'maa2', # Chennai
+    'syd', 'syd2', # Sydney
+    'dxb', # Dubai
+    'fra', # Frankfurt
+    'ams', # Amsterdam
+    'lhr', # London
+    'par', # Paris
+    'mad', # Madrid
+    'vie', # Vienna
+    'sto', 'sto2', # Stockholm
+    'waw', # Warsaw
+    'iad', # Virginia (US East)
+    'ord', # Chicago
+    'atl', # Atlanta
+    'dfw', # Dallas
+    'lax', # Los Angeles
+    'sea', # Seattle (US West)
+    'gru', # Sao Paulo
+    'eze', # Buenos Aires
+    'scl', # Santiago
+    'lim', # Lima
+    'jnb'  # Johannesburg
+)
+
+$discoveredPops = @{}
+foreach ($prop in $sdrConfig.pops.PSObject.Properties) {
+    $popCode = $prop.Name.ToLower()
+    $popData = $prop.Value
+    if ($popData.relays -and $popData.relays.Count -gt 0) {
+        $discoveredPops[$popCode] = $popData
+    }
+}
+
+Write-Host "Found $($discoveredPops.Count) active Valve SDR POPs with relays." -ForegroundColor Green
+
+# POPs aimed at Vietnamese players (Singapore primary, Hong Kong, Tokyo, Seoul)
+$vietnamPops = @('sgp', 'hkg', 'tyo', 'tyo1', 'tyo2', 'seo')
+
+$orderedPopCodes = @()
+$targetList = if ($All) { $priorityPops } else { $vietnamPops }
+foreach ($code in $targetList) {
+    if ($discoveredPops.ContainsKey($code)) {
+        $orderedPopCodes += $code
+    }
+}
+if ($All) {
+    foreach ($code in ($discoveredPops.Keys | Sort-Object)) {
+        if (-not ($orderedPopCodes -contains $code)) {
+            $orderedPopCodes += $code
+        }
+    }
+}
+
+$regions = @()
+$totalSubnets = 0
+
+foreach ($code in $orderedPopCodes) {
+    $pop = $discoveredPops[$code]
+    $name = if ($pop.desc) { $pop.desc } else { $code.ToUpper() }
+
+    # Extract relay IPs and convert to /24 subnets
+    $subnets = @()
+    foreach ($relay in $pop.relays) {
+        if ($relay.ipv4) {
+            $parts = $relay.ipv4.Split('.')
+            if ($parts.Count -eq 4) {
+                $subnet = "$($parts[0]).$($parts[1]).$($parts[2]).0/24"
+                if (-not ($subnets -contains $subnet)) {
+                    $subnets += $subnet
+                }
+            }
+        }
+    }
+
+    if ($subnets.Count -eq 0) { continue }
+
+    $regionEntry = [ordered]@{
+        id     = "cs2-$code"
+        name   = $name
+        source = "steam-sdr:$code"
+        note   = "Valve SDR $($code.ToUpper()) relay cluster."
+        cidrs  = $subnets
+    }
+
+    $regions += $regionEntry
+    $totalSubnets += $subnets.Count
+}
+
+$profile = [ordered]@{
+    schemaVersion = 1
+    generatedUtc  = [DateTime]::UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ")
+    note          = "CS2 COMPLETE server IPs - all $($regions.Count) Valve SDR POPs from Steam API (https://api.steampowered.com/ISteamApps/GetSDRConfig/v1/?appid=730). Generated $([DateTime]::UtcNow.ToString('yyyy-MM-dd'))."
+    games         = @(
+        [ordered]@{
+            id            = "cs2"
+            name          = "Counter-Strike 2"
+            processNames  = @("cs2.exe")
+            lobbyAddresses = @()
+            regions       = $regions
+        }
+    )
+    relays        = @(
+        [ordered]@{
+            id       = "relay-1"
+            name     = "Your relay"
+            location = "Singapore"
+            endpoint = $RelayEndpoint
+        }
+    )
+}
+
+$jsonOutput = Format-Json ($profile | ConvertTo-Json -Depth 20)
+
+if ($DryRun) {
+    Write-Host "Dry run completed: $($regions.Count) regions, $totalSubnets /24 subnets discovered." -ForegroundColor Yellow
+    return
+}
+
+$fullProfilePath = [System.IO.Path]::GetFullPath($ProfilePath)
+Write-Host "Writing CS2 profile to: $fullProfilePath" -ForegroundColor Cyan
+[System.IO.File]::WriteAllText($fullProfilePath, $jsonOutput, [System.Text.Encoding]::UTF8)
+
+# Run Test-Profile.ps1 to validate
+$testerPath = Join-Path $PSScriptRoot 'Test-Profile.ps1'
+if (Test-Path $testerPath) {
+    Write-Host "Validating generated profile with Test-Profile.ps1..." -ForegroundColor Cyan
+    & $testerPath -Path $fullProfilePath
+}
+
+Write-Host "CS2 profile generated and validated successfully ($totalSubnets subnets across $($regions.Count) Valve POPs)." -ForegroundColor Green


### PR DESCRIPTION
## What this changes

Adds multi-game optimization architecture with full support for **Counter-Strike 2 (CS2)** alongside PUBG. Introduces runtime localization support for **English** and **Vietnamese**, an in-app game selector, and automatic profile discovery for the installer.

### Key Additions

1. **Multi-Game & Game Selector**: Users can switch between PUBG and CS2 directly from the header dropdown. Service IPC and client view models now communicate game-specific context dynamically.

2. **Counter-Strike 2 Routing Profile**: Targeted profile for players in Vietnam covering the 4 regional Valve SDR POP clusters (Singapore `cs2-sgp`, Hong Kong `cs2-hkg`). Includes profile generation tooling (`Build-Cs2Profile.ps1`).

3. **Runtime Localization (English & Tiếng Việt)**: Introduces XML-based string catalogs with dynamic runtime language switching and persistence.

> [!IMPORTANT]
> Localization coverage is not yet complete across the entire application. Remaining hard-coded UI strings will be migrated incrementally.

4. **Automated Profile Packaging**: Inno Setup (`GamePingBooster.iss`) and build script (`gpb.ps1`) automatically package all production `*.json` game profiles while excluding `*.example.json` templates.

---

### Screenshots / UI Preview

#### Game Selection (PUBG / CS2)

<p align="center">
  <img width="422" height="541" alt="Game Selection" src="https://github.com/user-attachments/assets/8c353c66-e581-4172-b5cd-68b0205cc1cd" />
</p>

#### Settings menu

<p align="center">
  <img width="422" height="541" alt="image" src="https://github.com/user-attachments/assets/1f99c016-e0ae-4334-82db-7ab30b1f3f90" />
</p>

#### Connected State

<p align="center">
  <img
    src="https://github.com/user-attachments/assets/7a4715ca-2350-41cd-b83f-8260d72bf62e"
    alt="Connected State - PUBG"
    width="420"
  />
</p>

<p align="center"><em>PUBG</em></p>

<p align="center">
  <img
    src="https://github.com/user-attachments/assets/7ee63554-bf99-4390-97e8-e9e2c9a2cbb2"
    alt="Connect State - CS2"
    width="420"
  />
</p>

<p align="center"><em>Counter-Strike 2</em></p>

Fixes #

---

## How it was tested

- [x] `cd relay && go test ./...`
- [x] `cd client && dotnet build GamePingBooster.sln -c Release`
- [x] `dotnet run --project client/src/GamePingBooster.ProtocolCheck/GamePingBooster.ProtocolCheck.csproj` (58/58 test vectors passed; Go relay and C# client agree on all wire contracts)
- [x] `.\gpb.ps1 installer` (Verified Inno Setup automatically packages `pubg-vn.json` and `cs2-vn.json` into `GamePingBooster-Setup-0.2.1.exe`)
- [x] Tested in a real game session (Verified CS2 UDP SDR diversion and PUBG gameplay traffic redirection via tunnel). However, my SG VPS used for testing has poor routing and unusually high latency, so the tunnel provided only limited latency improvement in this test environment.

---

## Checklist

- [x] One logical change. A clean multi-game feature addition and regional localization.
- [x] No secrets, keys, tokens, real relay addresses or captured traffic in the diff. (All profiles and configs use RFC 5737 documentation addresses).
- [x] Comments explain **why**, not what - especially anywhere the obvious approach is wrong.
- [x] If this touches the wire protocol: **both** the Go relay and the C# client are updated, plus `testdata/protocol-vectors.json`, and ProtocolCheck passes.
- [x] If this could affect latency, I have measured it and said so below.

---

## Latency impact

- **PUBG**: No regression observed during testing.
- **CS2**: UDP gameplay traffic to the configured Singapore and Hong Kong Valve SDR ranges is successfully diverted through the relay.
- **Note**: Latency improvement could not be meaningfully evaluated with the current Singapore VPS due to its poor upstream routing and relatively high baseline latency.